### PR TITLE
Rename CCRC to GPLCC in COMMITMENT

### DIFF
--- a/COMMITMENT
+++ b/COMMITMENT
@@ -1,4 +1,4 @@
-Common Cure Rights Commitment, version 1.0
+GPL Cooperation Commitment, version 1.0
 
 Before filing or continuing to prosecute any legal proceeding or claim
 (other than a Defensive Action) arising from termination of a Covered
@@ -41,5 +41,5 @@ you or your affiliate.
 inclusion of this file, including subsidiaries of a corporate
 contributor.
 
-This work is available under a Creative Commons Attribution-ShareAlike
-4.0 International license.
+This work is available under a [Creative Commons Attribution-ShareAlike 4.0 International license]
+(https://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
The "Common Cure Rights Commitment" is being renamed to "GPL Cooperation Commitment".
As part of our effort to promote this initiative further we want to standardize on that name (GPLCC).

ref #4153
https://pulp.plan.io/issues/4153