### PR TITLE
Prepend Content model hierarchy with _

### DIFF
--- a/docs/workflows/sync.rst
+++ b/docs/workflows/sync.rst
@@ -58,7 +58,7 @@ Response::
 
     {
         "_href": "http://localhost:8000/pulp/api/v3/tasks/3896447a-2799-4818-a3e5-df8552aeb903/",
-        "created": "2018-05-01T17:17:46.558997Z",
+        "_created": "2018-05-01T17:17:46.558997Z",
         "created_resources": [
             "http://localhost:8000/pulp/api/v3/repositories/593e2fa9-af64-4d4b-aa7b-7078c96f2443/versions/6/"
         ],

--- a/docs/workflows/upload.rst
+++ b/docs/workflows/upload.rst
@@ -45,7 +45,7 @@ Response::
         "artifact": "http://localhost:8000/pulp/api/v3/artifacts/1/",
         "digest": "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c",
         "filename": "my-content",
-        "type": "plugin-template"
+        "_type": "plugin-template"
     }
 
 Add content to a repository


### PR DESCRIPTION
Prepend all pulpcore model fields in the Content model hierarchy with _
and do the same for all plugins reliant on them.

Required PR: https://github.com/pulp/pulp/pull/3798

re #4206
https://pulp.plan.io/issues/4206