### PR TITLE
Add back pulp_ to the plugin name template

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ change to create a 'real' plugin.
 
    ``$ ./bootstrap.py your_plugin_name``
 
+   **NOTE** : Whatever you choose for `your_plugin_name` will be prefixed with `pulp_`.
+   Therefore, for this argument it is best to just provide the content type
+   which you would like to support, e.g. `rubygem` or `maven`.
+
 
 In addition to the basic plugin boilerplate, this template also provides a basic set of
 functional tests using the [pulp_smash](https://pulp-smash.readthedocs.io/en/latest/) framework,

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -78,7 +78,7 @@ def main():
         parser.print_help()
         return 2
 
-    pulp_plugin_name = plugin_name
+    pulp_plugin_name = 'pulp_' + plugin_name
     replace_map = {
         TEMPLATE_SNAKE: pulp_plugin_name,
         TEMPLATE_SNAKE_SHORT: plugin_name,


### PR DESCRIPTION
Only app label stays without prefix.

[noissue]