### PR TITLE
Import new tests

### DIFF
--- a/pulp_plugin_template/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_plugin_template/tests/functional/api/test_crud_content_unit.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests that CRUD plugin_template content units."""
+"""Tests that perform actions over content unit."""
 import unittest
 
 from requests.exceptions import HTTPError
@@ -9,12 +9,12 @@ from pulp_smash.pulp3.constants import ARTIFACTS_PATH
 from pulp_smash.pulp3.utils import delete_orphans
 
 from pulp_plugin_template.tests.functional.constants import (
-    PLUGIN_TEMPLATE_URL,
     PLUGIN_TEMPLATE_CONTENT_PATH,
+    PLUGIN_TEMPLATE_URL,
 )
 from pulp_plugin_template.tests.functional.utils import (
     gen_plugin_template_content_attrs,
-    skip_if
+    skip_if,
 )
 from pulp_plugin_template.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 

--- a/pulp_plugin_template/tests/functional/api/test_crud_remotes.py
+++ b/pulp_plugin_template/tests/functional/api/test_crud_remotes.py
@@ -9,7 +9,7 @@ from pulp_smash import api, config, utils
 
 from pulp_plugin_template.tests.functional.constants import (
     DOWNLOAD_POLICIES,
-    PLUGIN_TEMPLATE_REMOTE_PATH
+    PLUGIN_TEMPLATE_REMOTE_PATH,
 )
 from pulp_plugin_template.tests.functional.utils import skip_if, gen_plugin_template_remote
 from pulp_plugin_template.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -112,6 +112,84 @@ class CreateRemoteNoURLTestCase(unittest.TestCase):
         del body['url']
         with self.assertRaises(HTTPError):
             api.Client(config.get_config()).post(PLUGIN_TEMPLATE_REMOTE_PATH, body)
+
+
+class RemoteDownloadPolicyTestCase(unittest.TestCase):
+    """Verify download policy behavior for valid and invalid values.
+
+    In Pulp 3, there are are different download policies.
+
+    This test targets the following testing scenarios:
+
+    1. Creating a remote without a download policy.
+       Verify the creation is successful and immediate it is policy applied.
+    2. Change the remote policy from default.
+       Verify the change is successful.
+    3. Attempt to change the remote policy to an invalid string.
+       Verify an HTTPError is given for the invalid policy as well
+       as the policy remaining unchanged.
+
+    For more information on the remote policies, see the Pulp3
+    API on an installed server:
+
+    * /pulp/api/v3/docs/#operation`
+
+    This test targets the following issues:
+
+    * `Pulp #4420 <https://pulp.plan.io/issues/4420>`_
+    * `Pulp #3763 <https://pulp.plan.io/issues/3763>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.remote = {}
+        cls.body = _gen_verbose_remote()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variable."""
+        cls.client.delete(cls.remote['_href'])
+
+    def test_01_no_defined_policy(self):
+        """Verify the default policy `immediate`.
+
+        When no policy is defined, the default policy of `immediate`
+        is applied.
+        """
+        del self.body['policy']
+        self.remote.update(self.client.post(PLUGIN_TEMPLATE_REMOTE_PATH, self.body))
+        self.assertEqual(self.remote['policy'], 'immediate', self.remote)
+
+    @skip_if(bool, 'remote', False)
+    def test_02_change_policy(self):
+        """Verify ability to change policy to value other than the default.
+
+        Update the remote policy to a valid value other than `immedaite`
+        and verify the new set value.
+        """
+        changed_policy = choice(
+            [item for item in DOWNLOAD_POLICIES if item != 'immediate']
+        )
+        self.client.patch(self.remote['_href'], {'policy': changed_policy})
+        self.remote.update(self.client.get(self.remote['_href']))
+        self.assertEqual(self.remote['policy'], changed_policy, self.remote)
+
+    @skip_if(bool, 'remote', False)
+    def test_03_invalid_policy(self):
+        """Verify an invalid policy does not update the remote policy.
+
+        Get the current remote policy.
+        Attempt to update the remote policy to an invalid value.
+        Verify the policy remains the same.
+        """
+        remote = self.client.get(self.remote['_href'])
+        with self.assertRaises(HTTPError):
+            self.client.patch(self.remote['_href'], {'policy': utils.uuid4()})
+        self.remote.update(self.client.get(self.remote['_href']))
+        self.assertEqual(remote['policy'], self.remote['policy'], self.remote)
 
 
 def _gen_verbose_remote():

--- a/pulp_plugin_template/tests/functional/api/test_download_content.py
+++ b/pulp_plugin_template/tests/functional/api/test_download_content.py
@@ -8,21 +8,22 @@ from urllib.parse import urljoin
 from pulp_smash import api, config, utils
 from pulp_smash.pulp3.constants import DISTRIBUTION_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import (
+    download_content_unit,
     gen_distribution,
     gen_repo,
     publish,
     sync,
 )
 
-from pulp_plugin_template.tests.functional.utils import (
-    gen_plugin_template_remote,
-    gen_plugin_template_publisher,
-    get_plugin_template_content_paths,
-)
 from pulp_plugin_template.tests.functional.constants import (
     PLUGIN_TEMPLATE_FIXTURE_URL,
-    PLUGIN_TEMPLATE_REMOTE_PATH,
     PLUGIN_TEMPLATE_PUBLISHER_PATH,
+    PLUGIN_TEMPLATE_REMOTE_PATH,
+)
+from pulp_plugin_template.tests.functional.utils import (
+    gen_plugin_template_publisher,
+    gen_plugin_template_remote,
+    get_plugin_template_content_paths,
 )
 from pulp_plugin_template.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
@@ -93,11 +94,7 @@ class DownloadContentTestCase(unittest.TestCase):
         ).hexdigest()
 
         # …and Pulp.
-        client.response_handler = api.safe_handler
+        content = download_content_unit(cfg, distribution, unit_path)
+        pulp_hash = hashlib.sha256(content).hexdigest()
 
-        unit_url = cfg.get_hosts('api')[0].roles['api']['scheme']
-        unit_url += '://' + distribution['base_url'] + '/'
-        unit_url = urljoin(unit_url, unit_path)
-
-        pulp_hash = hashlib.sha256(client.get(unit_url).content).hexdigest()
         self.assertEqual(fixtures_hash, pulp_hash)

--- a/pulp_plugin_template/tests/functional/api/test_download_policies.py
+++ b/pulp_plugin_template/tests/functional/api/test_download_policies.py
@@ -1,0 +1,98 @@
+# coding=utf-8
+"""Tests for Pulp`s download policies."""
+import unittest
+
+from pulp_smash import api, config
+from pulp_smash.pulp3.constants import REPO_PATH
+from pulp_smash.pulp3.utils import (
+    gen_repo,
+    get_added_content_summary,
+    get_content_summary,
+    sync,
+)
+
+from pulp_plugin_template.tests.functional.constants import (
+    PLUGIN_TEMPLATE_FIXTURE_SUMMARY,
+    PLUGIN_TEMPLATE_REMOTE_PATH,
+    DOWNLOAD_POLICIES,
+)
+from pulp_plugin_template.tests.functional.utils import (
+    gen_plugin_template_remote,
+    skip_if,
+)
+from pulp_plugin_template.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+
+
+# Implement sync support before enabling this test.
+@unittest.skip("FIXME: plugin writer action required")
+class SyncDownloadPolicyTestCase(unittest.TestCase):
+    """Sync a repository with different download policies.
+
+    This test targets the following issue:
+
+    `Pulp #4126 <https://pulp.plan.io/issues/4126>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+        cls.DP_ON_DEMAND = 'on_demand' in DOWNLOAD_POLICIES
+        cls.DP_STREAMED = 'streamed' in DOWNLOAD_POLICIES
+
+    @skip_if(bool, 'DP_ON_DEMAND', False)
+    def test_on_demand(self):
+        """Sync with ``on_demand`` download policy. See :meth:`do_test`."""
+        self.do_test('on_demand')
+
+    @skip_if(bool, 'DP_STREAMED', False)
+    def test_streamed(self):
+        """Sync with ``streamend`` download policy.  See :meth:`do_test`."""
+        self.do_test('streamed')
+
+    def do_test(self, download_policy):
+        """Sync repositories with the different ``download_policy``.
+
+        Do the following:
+
+        1. Create a repository, and a remote.
+        2. Assert that repository version is None.
+        3. Sync the remote.
+        4. Assert that repository version is not None.
+        5. Assert that the correct number of possible units to be downloaded
+           were shown.
+        6. Sync the remote one more time in order to create another repository
+           version.
+        7. Assert that repository version is different from the previous one.
+        8. Assert that the same number of units are shown, and after the
+           second sync no extra units should be shown, since the same remote
+           was synced again.
+        """
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
+
+        body = gen_plugin_template_remote(**{'policy': download_policy})
+        remote = self.client.post(PLUGIN_TEMPLATE_REMOTE_PATH, body)
+        self.addCleanup(self.client.delete, remote['_href'])
+
+        # Sync the repository.
+        self.assertIsNone(repo['_latest_version_href'])
+        sync(self.cfg, remote, repo)
+        repo = self.client.get(repo['_href'])
+
+        self.assertIsNotNone(repo['_latest_version_href'])
+        self.assertDictEqual(get_content_summary(repo), PLUGIN_TEMPLATE_FIXTURE_SUMMARY)
+        self.assertDictEqual(
+            get_added_content_summary(repo),
+            PLUGIN_TEMPLATE_FIXTURE_SUMMARY
+        )
+
+        # Sync the repository again.
+        latest_version_href = repo['_latest_version_href']
+        sync(self.cfg, remote, repo)
+        repo = self.client.get(repo['_href'])
+
+        self.assertNotEqual(latest_version_href, repo['_latest_version_href'])
+        self.assertDictEqual(get_content_summary(repo), PLUGIN_TEMPLATE_FIXTURE_SUMMARY)
+        self.assertDictEqual(get_added_content_summary(repo), {})

--- a/pulp_plugin_template/tests/functional/api/test_publish.py
+++ b/pulp_plugin_template/tests/functional/api/test_publish.py
@@ -16,14 +16,14 @@ from pulp_smash.pulp3.utils import (
     sync,
 )
 
-from pulp_plugin_template.tests.functional.utils import (
-    gen_plugin_template_remote,
-    gen_plugin_template_publisher,
-)
 from pulp_plugin_template.tests.functional.constants import (
     PLUGIN_TEMPLATE_CONTENT_NAME,
-    PLUGIN_TEMPLATE_REMOTE_PATH,
     PLUGIN_TEMPLATE_PUBLISHER_PATH,
+    PLUGIN_TEMPLATE_REMOTE_PATH,
+)
+from pulp_plugin_template.tests.functional.utils import (
+    gen_plugin_template_publisher,
+    gen_plugin_template_remote,
 )
 from pulp_plugin_template.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
 
@@ -93,6 +93,6 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         with self.assertRaises(HTTPError):
             body = {
                 'repository': repo['_href'],
-                'repository_version': non_latest
+                'repository_version': non_latest,
             }
             client.post(urljoin(publisher['_href'], 'publish/'), body)

--- a/pulp_plugin_template/tests/functional/api/test_publish.py
+++ b/pulp_plugin_template/tests/functional/api/test_publish.py
@@ -68,9 +68,9 @@ class PublishAnyRepoVersionTestCase(unittest.TestCase):
         self.addCleanup(client.delete, publisher['_href'])
 
         # Step 1
-        repo = self.client.get(repo['_href'])
+        repo = client.get(repo['_href'])
         for plugin_template_content in get_content(repo)[PLUGIN_TEMPLATE_CONTENT_NAME]:
-            self.client.post(
+            client.post(
                 repo['_versions_href'],
                 {'add_content_units': [plugin_template_content['_href']]}
             )

--- a/pulp_plugin_template/tests/functional/api/test_sync.py
+++ b/pulp_plugin_template/tests/functional/api/test_sync.py
@@ -2,18 +2,20 @@
 """Tests that sync plugin_template plugin repositories."""
 import unittest
 
-from pulp_smash import api, cli, config, exceptions
+from pulp_smash import api, cli, config
+from pulp_smash.exceptions import TaskReportError
 from pulp_smash.pulp3.constants import MEDIA_PATH, REPO_PATH
 from pulp_smash.pulp3.utils import (
     gen_repo,
-    get_content_summary,
     get_added_content_summary,
+    get_content_summary,
     sync,
 )
 
 from pulp_plugin_template.tests.functional.constants import (
     PLUGIN_TEMPLATE_FIXTURE_SUMMARY,
-    PLUGIN_TEMPLATE_REMOTE_PATH
+    PLUGIN_TEMPLATE_INVALID_FIXTURE_URL,
+    PLUGIN_TEMPLATE_REMOTE_PATH,
 )
 from pulp_plugin_template.tests.functional.utils import gen_plugin_template_remote
 from pulp_plugin_template.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
@@ -22,7 +24,7 @@ from pulp_plugin_template.tests.functional.utils import set_up_module as setUpMo
 # Implement sync support before enabling this test.
 @unittest.skip("FIXME: plugin writer action required")
 class BasicSyncTestCase(unittest.TestCase):
-    """Sync repositories with the plugin_template plugin."""
+    """Sync a repository with the plugin_template plugin."""
 
     @classmethod
     def setUpClass(cls):
@@ -43,8 +45,12 @@ class BasicSyncTestCase(unittest.TestCase):
         2. Assert that repository version is None.
         3. Sync the remote.
         4. Assert that repository version is not None.
-        5. Sync the remote one more time.
-        6. Assert that repository version is different from the previous one.
+        5. Assert that the correct number of units were added and are present
+           in the repo.
+        6. Sync the remote one more time.
+        7. Assert that repository version is different from the previous one.
+        8. Assert that the same number of are present and that no units were
+           added.
         """
         repo = self.client.post(REPO_PATH, gen_repo())
         self.addCleanup(self.client.delete, repo['_href'])
@@ -78,9 +84,11 @@ class BasicSyncTestCase(unittest.TestCase):
         """Test whether file descriptors are closed properly.
 
         This test targets the following issue:
+
         `Pulp #4073 <https://pulp.plan.io/issues/4073>`_
 
         Do the following:
+
         1. Check if 'lsof' is installed. If it is not, skip this test.
         2. Create and sync a repo.
         3. Run the 'lsof' command to verify that files in the
@@ -106,25 +114,46 @@ class BasicSyncTestCase(unittest.TestCase):
         self.assertEqual(len(response), 0, response)
 
 
-class SyncInvalidURLTestCase(unittest.TestCase):
-    """Sync a repository with an invalid url on the Remote."""
+# Implement sync support before enabling this test.
+@unittest.skip("FIXME: plugin writer action required")
+class SyncInvalidTestCase(unittest.TestCase):
+    """Sync a repository with a given url on the remote."""
 
-    def test_all(self):
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.cfg = config.get_config()
+        cls.client = api.Client(cls.cfg, api.json_handler)
+
+    def test_invalid_url(self):
+        """Sync a repository using a remote url that does not exist.
+
+        Test that we get a task failure. See :meth:`do_test`.
         """
-        Sync a repository using a Remote url that does not exist.
+        context = self.do_test('http://i-am-an-invalid-url.com/invalid/')
+        self.assertIsNotNone(context.exception.task['error']['description'])
 
-        Test that we get a task failure.
+    # Provide an invalid repository and specify keywords in the anticipated error message
+    @unittest.skip("FIXME: Plugin writer action required.")
+    def test_invalid_plugin_template_content(self):
+        """Sync a repository using an invalid plugin_content repository.
 
+        Assert that an exception is raised, and that error message has
+        keywords related to the reason of the failure. See :meth:`do_test`.
         """
-        cfg = config.get_config()
-        client = api.Client(cfg, api.json_handler)
+        context = self.do_test(PLUGIN_TEMPLATE_INVALID_FIXTURE_URL)
+        for key in ('mismached', 'empty'):
+            self.assertIn(key, context.exception.task['error']['description'])
 
-        repo = client.post(REPO_PATH, gen_repo())
-        self.addCleanup(client.delete, repo['_href'])
+    def do_test(self, url):
+        """Sync a repository given ``url`` on the remote."""
+        repo = self.client.post(REPO_PATH, gen_repo())
+        self.addCleanup(self.client.delete, repo['_href'])
 
-        body = gen_plugin_template_remote(url="http://i-am-an-invalid-url.com/invalid/")
-        remote = client.post(PLUGIN_TEMPLATE_REMOTE_PATH, body)
-        self.addCleanup(client.delete, remote['_href'])
+        body = gen_plugin_template_remote(url=url)
+        remote = self.client.post(PLUGIN_TEMPLATE_REMOTE_PATH, body)
+        self.addCleanup(self.client.delete, remote['_href'])
 
-        with self.assertRaises(exceptions.TaskReportError):
-            sync(cfg, remote, repo)
+        with self.assertRaises(TaskReportError) as context:
+            sync(self.cfg, remote, repo)
+        return context

--- a/pulp_plugin_template/tests/functional/constants.py
+++ b/pulp_plugin_template/tests/functional/constants.py
@@ -38,7 +38,7 @@ PLUGIN_TEMPLATE_FIXTURE_SUMMARY = {
 # FIXME: replace this with the location of one specific content unit of your choosing
 PLUGIN_TEMPLATE_URL = urljoin(PLUGIN_TEMPLATE_FIXTURE_URL, '')
 
-# FIXME: replace this iwth your own fixture repository URL and metadata
+# FIXME: replace this with your own fixture repository URL and metadata
 PLUGIN_TEMPLATE_LARGE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'plugin_template_large/')
 
 # FIXME: replace this with the actual number of content units in your test fixture

--- a/pulp_plugin_template/tests/functional/constants.py
+++ b/pulp_plugin_template/tests/functional/constants.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+"""Constants for Pulp PluginTemplate plugin tests."""
 from urllib.parse import urljoin
 
 from pulp_smash.constants import PULP_FIXTURES_BASE_URL
@@ -24,22 +25,31 @@ PLUGIN_TEMPLATE_REMOTE_PATH = urljoin(BASE_REMOTE_PATH, 'plugin_template/plugin-
 
 PLUGIN_TEMPLATE_PUBLISHER_PATH = urljoin(BASE_PUBLISHER_PATH, 'plugin_template/plugin-template/')
 
-
 # FIXME: replace this with your own fixture repository URL and metadata
 PLUGIN_TEMPLATE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'plugin_template/')
+"""The URL to a plugin_template repository."""
 
 # FIXME: replace this with the actual number of content units in your test fixture
 PLUGIN_TEMPLATE_FIXTURE_COUNT = 3
+"""The number of content units available at :data:`PLUGIN_TEMPLATE_FIXTURE_URL`."""
 
 PLUGIN_TEMPLATE_FIXTURE_SUMMARY = {
-    PLUGIN_TEMPLATE_CONTENT_NAME: PLUGIN_TEMPLATE_FIXTURE_COUNT
+    PLUGIN_TEMPLATE_CONTENT_NAME: PLUGIN_TEMPLATE_FIXTURE_COUNT,
 }
+"""The desired content summary after syncing :data:`PLUGIN_TEMPLATE_FIXTURE_URL`."""
 
 # FIXME: replace this with the location of one specific content unit of your choosing
 PLUGIN_TEMPLATE_URL = urljoin(PLUGIN_TEMPLATE_FIXTURE_URL, '')
+"""The URL to an plugin_template file at :data:`PLUGIN_TEMPLATE_FIXTURE_URL`."""
+
+# FIXME: replace this with your own fixture repository URL and metadata
+PLUGIN_TEMPLATE_INVALID_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'plugin_template-invalid/')
+"""The URL to an invalid plugin_template repository."""
 
 # FIXME: replace this with your own fixture repository URL and metadata
 PLUGIN_TEMPLATE_LARGE_FIXTURE_URL = urljoin(PULP_FIXTURES_BASE_URL, 'plugin_template_large/')
+"""The URL to a plugin_template repository containing a large number of content units."""
 
 # FIXME: replace this with the actual number of content units in your test fixture
 PLUGIN_TEMPLATE_LARGE_FIXTURE_COUNT = 25
+"""The number of content units available at :data:`PLUGIN_TEMPLATE_LARGE_FIXTURE_URL`."""

--- a/pulp_plugin_template/tests/functional/utils.py
+++ b/pulp_plugin_template/tests/functional/utils.py
@@ -46,7 +46,7 @@ def gen_plugin_template_remote(**kwargs):
 
 
 def gen_plugin_template_publisher(**kwargs):
-    """Return a semi-random dict for use in creating a Remote.
+    """Return a semi-random dict for use in creating a Publisher.
 
     :param url: The URL of an external content source.
     """

--- a/pulp_plugin_template/tests/functional/utils.py
+++ b/pulp_plugin_template/tests/functional/utils.py
@@ -4,17 +4,15 @@ from functools import partial
 from unittest import SkipTest
 
 from pulp_smash import api, selectors
-from pulp_smash.pulp3.constants import (
-    REPO_PATH
-)
+from pulp_smash.pulp3.constants import REPO_PATH
 from pulp_smash.pulp3.utils import (
+    gen_publisher,
     gen_remote,
     gen_repo,
-    gen_publisher,
     get_content,
     require_pulp_3,
     require_pulp_plugins,
-    sync
+    sync,
 )
 
 from pulp_plugin_template.tests.functional.constants import (
@@ -31,38 +29,29 @@ def set_up_module():
     require_pulp_plugins({'pulp_plugin_template'}, SkipTest)
 
 
-def gen_plugin_template_remote(**kwargs):
+def gen_plugin_template_remote(url=PLUGIN_TEMPLATE_FIXTURE_URL, **kwargs):
     """Return a semi-random dict for use in creating a plugin_template Remote.
 
     :param url: The URL of an external content source.
     """
-    remote = gen_remote(PLUGIN_TEMPLATE_FIXTURE_URL)
     # FIXME: Add any fields specific to a plugin_template remote here
-    plugin_template_extra_fields = {
-        **kwargs
-    }
-    remote.update(**plugin_template_extra_fields)
-    return remote
+    return gen_remote(url, **kwargs)
 
 
 def gen_plugin_template_publisher(**kwargs):
-    """Return a semi-random dict for use in creating a Publisher.
+    """Return a semi-random dict for use in creating a plugin_template Publisher.
 
     :param url: The URL of an external content source.
     """
-    publisher = gen_publisher()
     # FIXME: Add any fields specific to a plugin_teplate publisher here
-    plugin_template_extra_fields = {
-        **kwargs
-    }
-    publisher.update(**plugin_template_extra_fields)
-    return publisher
+    return gen_publisher(**kwargs)
 
 
-def get_plugin_template_content_unit_paths(repo):
+def get_plugin_template_content_paths(repo, version_href=None):
     """Return the relative path of content units present in a plugin_template repository.
 
     :param repo: A dict of information about the repository.
+    :param version_href: The repository version to read.
     :returns: A list with the paths of units present in a given repository.
     """
     # FIXME: The "relative_path" is actually a file path and name
@@ -70,14 +59,14 @@ def get_plugin_template_content_unit_paths(repo):
     # for repositories of this content type.
     return [
         content_unit['relative_path']
-        for content_unit in get_content(repo)[PLUGIN_TEMPLATE_CONTENT_NAME]
+        for content_unit in get_content(repo, version_href)[PLUGIN_TEMPLATE_CONTENT_NAME]
     ]
 
 
 def gen_plugin_template_content_attrs(artifact):
     """Generate a dict with content unit attributes.
 
-    :param: artifact: A dict of info about the artifact.
+    :param artifact: A dict of info about the artifact.
     :returns: A semi-random dict for use in creating a content unit.
     """
     # FIXME: Add content specific metadata here.
@@ -90,7 +79,7 @@ def populate_pulp(cfg, url=PLUGIN_TEMPLATE_FIXTURE_URL):
     :param pulp_smash.config.PulpSmashConfig: Information about a Pulp application.
     :param url: The plugin_template repository URL. Defaults to
         :data:`pulp_smash.constants.PLUGIN_TEMPLATE_FIXTURE_URL`
-    :returns: A list of dicts, where each dict describes one file content in Pulp.
+    :returns: A list of dicts, where each dict describes one plugin_template content in Pulp.
     """
     client = api.Client(cfg, api.json_handler)
     remote = {}
@@ -107,7 +96,7 @@ def populate_pulp(cfg, url=PLUGIN_TEMPLATE_FIXTURE_URL):
     return client.get(PLUGIN_TEMPLATE_CONTENT_PATH)['results']
 
 
-skip_if = partial(selectors.skip_if, exc=SkipTest)
+skip_if = partial(selectors.skip_if, exc=SkipTest)  # pylint:disable=invalid-name
 """The ``@skip_if`` decorator, customized for unittest.
 
 :func:`pulp_smash.selectors.skip_if` is test runner agnostic. This function is

--- a/pulp_plugin_template/tests/unit/test_serializers.py
+++ b/pulp_plugin_template/tests/unit/test_serializers.py
@@ -1,0 +1,40 @@
+import unittest
+from django.test import TestCase
+
+from pulp_plugin_template.app.serializers import PluginTemplateContentSerializer
+from pulp_plugin_template.app.models import PluginTemplateContent
+
+from pulpcore.plugin.models import Artifact
+
+
+# Fill data with sufficient information to create PluginTemplateContent
+# Provide sufficient parameters to create the PluginTemplateContent object
+# Depending on the base class of the serializer, provide either '_artifact' or '_artifacts'
+@unittest.skip("FIXME: plugin writer action required")
+class TestPluginTemplateContentSerializer(TestCase):
+    """Test PluginTemplateContentSerializer."""
+
+    def setUp(self):
+        """Set up the PluginTemplateContentSerializer tests."""
+        self.artifact = Artifact.objects.create(
+            md5="ec0df26316b1deb465d2d18af7b600f5",
+            sha1="cf6121b0425c2f2e3a2fcfe6f402d59730eb5661",
+            sha224="9a6297eb28d91fad5277c0833856031d0e940432ad807658bd2b60f4",
+            sha256="c8ddb3dcf8da48278d57b0b94486832c66a8835316ccf7ca39e143cbfeb9184f",
+            sha384="53a8a0cebcb7780ed7624790c9d9a4d09ba74b47270d397f5ed7bc1c46777a0fbe362aaf2bbe7f0966a350a12d76e28d",  # noqa
+            sha512="a94a65f19b864d184a2a5e07fa29766f08c6d49b6f624b3dd3a36a98267b9137d9c35040b3e105448a869c23c2aec04c9e064e3555295c1b8de6515eed4da27d",  # noqa
+            size=1024
+        )
+
+    def test_valid_data(self):
+        """Test that the PluginTemplateContentSerializer accepts valid data."""
+        data = {"_artifact": "/pulp/api/v3/artifacts/{}/".format(self.artifact.pk)}
+        serializer = PluginTemplateContentSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+
+    def test_duplicate_data(self):
+        """Test that the PluginTemplateContentSerializer does not accept data."""
+        PluginTemplateContent.objects.create(artifact=artifact)
+        data = {"_artifact": "/pulp/api/v3/artifacts/{}/".format(self.artifact.pk)}
+        serializer = PluginTemplateContentSerializer(data=data)
+        self.assertFalse(serializer.is_valid())


### PR DESCRIPTION
 This PR started out to fix some small typos in the `tests` directory, but it ended up pulling new tests from pulp_file.

Please consider this PR together with
https://github.com/pulp/pulp_file/pull/168
together they should minimize the diff on both `tests` directories.