### PR TITLE
Build REST API docs for publishing on rtd

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -42,6 +42,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
+	curl -o _static/api.json "http://localhost:24817/pulp/api/v3/docs/api.json?plugin=plugin_template"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/docs/_static/api.json
+++ b/docs/_static/api.json
@@ -1,0 +1,1 @@
+{"swagger": "2.0", "info": {"title": "Pulp 3 API", "version": "v3"}, "host": "localhost:24817", "schemes": ["http"], "basePath": "/", "consumes": ["application/json"], "produces": ["application/json"], "securityDefinitions": {"Basic": {"type": "basic"}}, "security": [{"Basic": []}], "paths": {}, "definitions": {}, "tags": []}

--- a/docs/_templates/restapi.html
+++ b/docs/_templates/restapi.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>REST API for Pulp 3 Python Plugin</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='_static/api.json'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,9 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()] if sphinx_rtd_theme e
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
 #html_additional_pages = {}
+html_additional_pages = {'restapi': 'restapi.html'}
+
+html_static_path = ['_static']
 
 # If false, no module index is generated.
 #html_domain_indices = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,12 +2,24 @@ plugin-template Plugin
 ======================
 
 The ``plugin-template`` plugin extends `pulpcore <https://pypi.python.org/pypi/pulpcore/>`__ to support
-hosting plugin-template packages. This plugin is a part of the `Pulp Project
-<http://www.pulpproject.org>`_, and assumes some familiarity with the `pulpcore documentation
-<https://docs.pulpproject.org/en/3.0/nightly/>`_.
+hosting plugin-template packages.
 
 If you are just getting started, we recommend getting to know the :doc:`basic
 workflows<workflows/index>`.
+
+How to use these docs
+---------------------
+
+The documentation here should be considered **the primary documentation for managing Python
+content**. All relevent workflows are covered here, with references to some pulpcore supplemental
+docs. Users may also find `pulpcore's conceptual docs
+<https://docs.pulpproject.org/en/3.0/nightly/concepts.html>`_ useful. Here, the documentation falls
+into two main categories:
+
+  1. :ref:`workflows-index` show the **major features** of the plugin-template plugin, with links to
+     reference docs.
+  2. `REST API Docs <restapi.html>`_ are automatically generated and provide more detailed
+     information for each **minor feature**, including all fields and options.
 
 
 Table of Contents
@@ -18,7 +30,8 @@ Table of Contents
 
    installation
    workflows/index
-   release-notes/3.0.z.rst
+   restapi/index
+   release-notes/0.0.z.rst
 
 
 Indices and tables

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ User Setup
 All REST API examples below use `httpie <https://httpie.org/doc>`__ to
 perform the requests.
 
-.. code-block::
+.. code-block:: bash
 
     machine localhost
     login admin

--- a/docs/restapi/index.rst
+++ b/docs/restapi/index.rst
@@ -1,0 +1,9 @@
+REST API
+========
+
+Pulpcore Reference: `pulpcore REST documentation <https://docs.pulpproject.org/en/3.0/nightly/restapi.html>`_.
+
+Plugin_Template Endpoints
+-------------------------
+
+REST API Reference `plugin-template REST documentation <../restapi.html>`_

--- a/docs/workflows/index.rst
+++ b/docs/workflows/index.rst
@@ -1,3 +1,5 @@
+.. _workflows-index:
+
 Workflows
 =========
 
@@ -30,4 +32,5 @@ set is the hostname and port::
 
    sync
    upload
-   publish-host
+   publish
+


### PR DESCRIPTION
With `make html` and hosting the build directory with a simple server,
this PR adds a swagger docs page
http://localhost:1234/restapi.html#section/Authentication

re #4637