### PR TITLE
Have __version__ use correct replacement string

### DIFF
--- a/pulp_plugin_template/__init__.py
+++ b/pulp_plugin_template/__init__.py
@@ -1,5 +1,5 @@
 import pkg_resources
 
-__version__ = pkg_resources.get_distribution("default_app_config").version
+__version__ = pkg_resources.get_distribution("pulp-plugin-template").version
 
 default_app_config = 'pulp_plugin_template.app.PulpPluginTemplatePluginAppConfig'


### PR DESCRIPTION
This needs to use the setup.py name to work correctly.

https://pulp.plan.io/issues/4875
re #4875