### PR TITLE
Remove release note vestige

### DIFF
--- a/meta_docs/reference/releasing.md
+++ b/meta_docs/reference/releasing.md
@@ -7,6 +7,4 @@ Packaging
 The Plugin API is available from PyPI as pulpcore-plugin. A plugin writer needs to specify the
 minimum version of pulpcore-plugin their plugin is dependent on. A plugin writer does not need to
 specify which version of pulpcore would work with their plugin since pulpcore-plugin will
-resolve the pulpcore dependency. Please see :doc:`release notes <../../release-notes/index>`
-for the supported versions of pulpcore.
-
+resolve the pulpcore dependency.


### PR DESCRIPTION
This prevents correct building of the sphinx project.

https://pulp.plan.io/issues/4875
re #4875