### PR TITLE
Problem: sudo is used to generate bindings

### DIFF
--- a/templates/.travis/before_install.sh
+++ b/templates/.travis/before_install.sh
@@ -7,6 +7,7 @@ export PULP_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/g
 export PULP_PLUGIN_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulpcore-plugin\/pull\/(\d+)' | awk -F'/' '{print $7}')
 export PULP_SMASH_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/PulpQE\/pulp-smash\/pull\/(\d+)' | awk -F'/' '{print $7}')
 export PULP_ROLES_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/ansible-pulp\/pull\/(\d+)' | awk -F'/' '{print $7}')
+export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-openapi-generator\/pull\/(\d+)' | awk -F'/' '{print $7}')
 
 # dev_requirements should not be needed for testing; don't install them to make sure
 pip install -r test_requirements.txt

--- a/templates/.travis/publish_client_gem.sh
+++ b/templates/.travis/publish_client_gem.sh
@@ -28,8 +28,7 @@ cd
 git clone https://github.com/pulp/pulp-openapi-generator.git
 cd pulp-openapi-generator
 
-sudo ./generate.sh {{ plugin_snake_name }} ruby $VERSION
-sudo chown -R travis:travis {{ plugin_snake_name }}-client
+./generate.sh {{ plugin_snake_name }} ruby $VERSION
 cd {{ plugin_snake_name }}-client
 gem build {{ plugin_snake_name }}_client
 GEM_FILE="$(ls | grep {{ plugin_snake_name }}_client-)"

--- a/templates/.travis/publish_client_pypi.sh
+++ b/templates/.travis/publish_client_pypi.sh
@@ -26,8 +26,7 @@ cd
 git clone https://github.com/pulp/pulp-openapi-generator.git
 cd pulp-openapi-generator
 
-sudo ./generate.sh {{ plugin_snake_name }} python $VERSION
-sudo chown -R travis:travis {{ plugin_snake_name }}-client
+./generate.sh {{ plugin_snake_name }} python $VERSION
 cd {{ plugin_snake_name }}-client
 python setup.py sdist bdist_wheel --python-tag py3
 twine upload dist/* -u pulp -p $PYPI_PASSWORD

--- a/templates/.travis/script.sh
+++ b/templates/.travis/script.sh
@@ -38,16 +38,16 @@ if [ "$TEST" = 'bindings' ]; then
   export PULP_BINDINGS_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/pulp-swagger-codegen\/pull\/(\d+)' | awk -F'/' '{print $7}')
 
   cd ..
-  git clone https://github.com/pulp/pulp-swagger-codegen.git
-  cd pulp-swagger-codegen
+  git clone https://github.com/pulp/pulp-openapi-generator.git
+  cd pulp-openapi-generator
 
   if [ -n "$PULP_BINDINGS_PR_NUMBER" ]; then
     git fetch origin +refs/pull/$PULP_BINDINGS_PR_NUMBER/merge
     git checkout FETCH_HEAD
   fi
 
-  sudo ./generate.sh pulpcore python
-  sudo ./generate.sh {{ plugin_snake_name }} python
+  ./generate.sh pulpcore python
+  ./generate.sh {{ plugin_snake_name }} python
   pip install ./pulpcore-client
   pip install ./{{ plugin_snake_name }}-client
   python $TRAVIS_BUILD_DIR/.travis/test_bindings.py


### PR DESCRIPTION
Solution: stop using sudo

The pulp-openapi-generator script was recently update to run the container in user space.
This patch takes advantage of that change.

This patch also provides plugins the ability to specify a required PR from the
pulp-openapi-generator repository.

[noissue]