### PR TITLE
Don't add .dev release part of the version

### DIFF
--- a/templates/.travis/publish_client_gem.sh
+++ b/templates/.travis/publish_client_gem.sh
@@ -14,7 +14,7 @@ if [[ $DESCRIPTION == 'tags/'$REPORTED_VERSION ]]; then
   export VERSION=${REPORTED_VERSION}
 else
   export EPOCH="$(date +%s)"
-  export VERSION=${REPORTED_VERSION}.dev.${EPOCH}
+  export VERSION=${REPORTED_VERSION}.${EPOCH}
 fi
 
 export response=$(curl --write-out %{http_code} --silent --output /dev/null https://rubygems.org/gems/{{ plugin_snake_name }}_client/versions/$VERSION)


### PR DESCRIPTION
It should be done by Pulp 3 plugins themselves.
Their master branch should contain .dev release segment
in the version identifier of the upcoming release.

closes #4936
https://pulp.plan.io/issues/4936