### PR TITLE
Problem: CONTENT_HOST is not set by the installer

### DIFF
--- a/travis_templates/.travis/playbook.yml.j2
+++ b/travis_templates/.travis/playbook.yml.j2
@@ -19,6 +19,7 @@
     pulp_db_user: 'travis'
     pulp_db_password: ''
     pulp_preq_packages: []
+    pulp_content_host: 'localhost:24816'
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
   roles:


### PR DESCRIPTION
Solution: add pulp_content_host to the playbook used for installing

[noissue]