### PR TITLE
Add detail Remote 'policy' redefinition docs

### DIFF
--- a/bootstrap_templates/app/serializers.py.j2
+++ b/bootstrap_templates/app/serializers.py.j2
@@ -53,6 +53,17 @@ class {{ plugin_camel_short }}RemoteSerializer(platform.RemoteSerializer):
 
     class Meta:
         validators = platform.RemoteSerializer.Meta.validators + [myValidator1, myValidator2]
+
+    By default the 'policy' field in platform.RemoteSerializer only validates the choice
+    'immediate'. To add on-demand support for more 'policy' options, e.g. 'streamed' or 'on_demand',
+    re-define the 'policy' option as follows::
+
+    policy = serializers.ChoiceField(
+        help_text="The policy to use when downloading content. The possible values include: "
+                  "'immediate', 'on_demand', and 'streamed'. 'immediate' is the default.",
+        choices=models.Remote.POLICY_CHOICES,
+        default=models.Remote.IMMEDIATE
+    )
     """
 
     class Meta:


### PR DESCRIPTION
To use on-demand content with more 'policy' values the Remote Serializer
needs to redefine the 'policy' attribute. This is now included in the
docstring so plugin writers can decide.

https://pulp.plan.io/issues/4990
closes #4990