### PR TITLE
Bump pulpcore-plugin dependency to 0.1.0rc3

### DIFF
--- a/templates/boostrap/setup.py.j2
+++ b/templates/boostrap/setup.py.j2
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    'pulpcore-plugin>=0.1.0b18',
+    'pulpcore-plugin>=0.1.0rc3',
 ]
 
 setup(


### PR DESCRIPTION
[noissue]

I guess when bootstrapping a plugin today, we do not want it to depend on a version of the plugin api that is massively incompatible with the current rc.