### PR TITLE
Fix: Make dirs depend on TRAVIS_BUILD_ROOT

### DIFF
--- a/templates/travis/.travis/playbook.yml.j2
+++ b/templates/travis/.travis/playbook.yml.j2
@@ -7,8 +7,8 @@
       include_vars: '{% raw %}{{ pulp_db_type }}{% endraw %}.yml'
   vars:
     pulp_default_admin_password: admin
-    pulp_source_dir: '/home/travis/build/pulp/pulpcore/'
-    pulp_plugin_source_dir: "/home/travis/build/pulp/pulpcore-plugin"
+    pulp_source_dir: '{% raw %}{{ ansible_env.TRAVIS_BUILD_DIR | dirname }}{% endraw %}/pulpcore/'
+    pulp_plugin_source_dir: "{% raw %}{{ ansible_env.TRAVIS_BUILD_DIR | dirname }}{% endraw %}/pulpcore-plugin"
     pulp_install_plugins:
       {{ plugin_dash }}:
         app_label: "{{ plugin_name }}"

--- a/templates/travis/.travis/publish_client_pypi.sh.j2
+++ b/templates/travis/.travis/publish_client_pypi.sh.j2
@@ -7,7 +7,7 @@ pip install twine
 django-admin runserver 24817 >> ~/django_runserver.log 2>&1 &
 sleep 5
 
-cd /home/travis/build/pulp/{{ plugin_snake }}/
+cd "${TRAVIS_BUILD_DIR}"
 export REPORTED_VERSION=$(http :24817/pulp/api/v3/status/ | jq --arg plugin {{ plugin_snake }} -r '.versions[] | select(.component == $plugin) | .version')
 export DESCRIPTION="$(git describe --all --exact-match `git rev-parse HEAD`)"
 if [[ $DESCRIPTION == 'tags/'$REPORTED_VERSION ]]; then


### PR DESCRIPTION
The build directory `/home/travis/build/pulp/...` actually only works for
repositories in the `pulp` GitHub group.  For other repositories `/pulp/` is
the group/user name.

Fix this be using the environment variable TRAVIS_BUILD_ROOT (which points
into the checked out git repository currently being tested).

[noissue]