### PR TITLE
Fix bash syntax error in wait_for_pulp() if Pulp does not respond

### DIFF
--- a/templates/travis/.travis/script.sh.j2
+++ b/templates/travis/.travis/script.sh.j2
@@ -20,7 +20,7 @@ wait_for_pulp() {
     echo -n .
     sleep 1
     TIMEOUT=$(($TIMEOUT - 1))
-    if [ $(http :24817/pulp/api/v3/status/ | jq '.database_connection.connected and .redis_connection.connected') = 'true' ]
+    if [ "$(http :24817/pulp/api/v3/status/ 2>/dev/null | jq '.database_connection.connected and .redis_connection.connected')" = "true" ]
     then
       echo
       return


### PR DESCRIPTION
In case the connection to Pulp could not be established at all, bash ran
into a syntax error (one side of the "=" comparison was completely empty):

```
travis/script.sh: line 28: [: =: unary operator expected
```

Fix this and suppress the error messages from httpd (which may confuse the
reader of the CI log when trying to find out the cause of an error).

[noissue]