### PR TITLE
Improve before_install.sh

### DIFF
--- a/templates/travis/.travis/before_install.sh.j2
+++ b/templates/travis/.travis/before_install.sh.j2
@@ -1,8 +1,8 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 {% include 'header.j2' %}
 
-set -v
+set -mveuo pipefail
 
 export PRE_BEFORE_INSTALL=$TRAVIS_BUILD_DIR/.travis/pre_before_install.sh
 export POST_BEFORE_INSTALL=$TRAVIS_BUILD_DIR/.travis/post_before_install.sh
@@ -27,46 +27,46 @@ pip install -r test_requirements.txt
 ./.travis/check_commit.sh{% endif %}
 
 # Lint code.
-flake8 --config flake8.cfg || exit 1
+flake8 --config flake8.cfg
 
 {% if not exclude_black %}# check the code style with black
-black --check --diff . || exit 1{% endif %}
+black --check --diff .{% endif %}
 
 cd ..
-git clone https://github.com/pulp/ansible-pulp.git
+git clone --depth=1 https://github.com/pulp/ansible-pulp.git
 if [ -n "$PULP_ROLES_PR_NUMBER" ]; then
-  pushd ansible-pulp
-  git fetch origin +refs/pull/$PULP_ROLES_PR_NUMBER/merge
+  cd ansible-pulp
+  git fetch --depth=1 origin +refs/pull/$PULP_ROLES_PR_NUMBER/merge
   git checkout FETCH_HEAD
-  popd
+  cd ..
 fi
 
-{% if plugin_name != 'pulpcore' %}git clone https://github.com/pulp/pulpcore.git
+{% if plugin_name != 'pulpcore' %}git clone --depth=1 https://github.com/pulp/pulpcore.git
 
 if [ -n "$PULP_PR_NUMBER" ]; then
-  pushd pulpcore
-  git fetch origin +refs/pull/$PULP_PR_NUMBER/merge
+  cd pulpcore
+  git fetch --depth=1 origin +refs/pull/$PULP_PR_NUMBER/merge
   git checkout FETCH_HEAD
-  popd
+  cd ..
 fi
 {% endif %}
 
-git clone https://github.com/pulp/pulpcore-plugin.git
+git clone --depth=1 https://github.com/pulp/pulpcore-plugin.git
 
 if [ -n "$PULP_PLUGIN_PR_NUMBER" ]; then
-  pushd pulpcore-plugin
-  git fetch origin +refs/pull/$PULP_PLUGIN_PR_NUMBER/merge
+  cd pulpcore-plugin
+  git fetch --depth=1 origin +refs/pull/$PULP_PLUGIN_PR_NUMBER/merge
   git checkout FETCH_HEAD
-  popd
+  cd ..
 fi
 
 
 if [ -n "$PULP_SMASH_PR_NUMBER" ]; then
-  git clone https://github.com/PulpQE/pulp-smash.git
-  pushd pulp-smash
-  git fetch origin +refs/pull/$PULP_SMASH_PR_NUMBER/merge
+  git clone --depth=1 https://github.com/PulpQE/pulp-smash.git
+  cd pulp-smash
+  git fetch --depth=1 origin +refs/pull/$PULP_SMASH_PR_NUMBER/merge
   git checkout FETCH_HEAD
-  popd
+  cd ..
 fi
 
 if [ "$DB" = 'mariadb' ]; then


### PR DESCRIPTION
- Use bash and the more secure `set -mveuo pipefail` (as in other scripts)

- Use shallow clones and shallow fetch to speed up the CI run (Especially
  pulpcore takes a long time to clone completely.  We don't need any history
  when building in the CI.)

- get rid of pushd/popd (bashism that is not needed here)

https://pulp.plan.io/issues/5078
fixes #5078