### PR TITLE
Use -f instead of -x to check for hooks

### DIFF
--- a/templates/travis/.travis/before_install.sh.j2
+++ b/templates/travis/.travis/before_install.sh.j2
@@ -10,7 +10,7 @@ export POST_BEFORE_INSTALL=$TRAVIS_BUILD_DIR/.travis/post_before_install.sh
 COMMIT_MSG=$(git log --format=%B --no-merges -1)
 export COMMIT_MSG
 
-if [ -x $PRE_BEFORE_INSTALL ]; then
+if [ -f $PRE_BEFORE_INSTALL ]; then
     $PRE_BEFORE_INSTALL
 fi
 
@@ -77,6 +77,6 @@ cp {{ plugin_snake }}/.travis/postgres.yml ansible-pulp/postgres.yml
 
 cd {{ plugin_snake }}
 
-if [ -x $POST_BEFORE_INSTALL ]; then
+if [ -f $POST_BEFORE_INSTALL ]; then
     $POST_BEFORE_INSTALL
 fi

--- a/templates/travis/.travis/script.sh.j2
+++ b/templates/travis/.travis/script.sh.j2
@@ -37,7 +37,7 @@ if [ "$TEST" = 'docs' ]; then
   make html
   cd ..
 
-  if [ -x $POST_DOCS_TEST ]; then
+  if [ -f $POST_DOCS_TEST ]; then
       $POST_DOCS_TEST
   fi
   exit
@@ -122,7 +122,7 @@ coverage run $(which django-admin) runserver 24817 --noreload >> ~/django_runser
 wait_for_pulp 20
 
 # Run functional tests
-if [ -x $FUNC_TEST_SCRIPT ]; then
+if [ -f $FUNC_TEST_SCRIPT ]; then
     $FUNC_TEST_SCRIPT
 else
     pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional || show_logs_and_return_non_zero
@@ -138,6 +138,6 @@ wait || true
 coverage combine
 codecov
 {% endif %}
-if [ -x $POST_SCRIPT ]; then
+if [ -f $POST_SCRIPT ]; then
     $POST_SCRIPT
 fi


### PR DESCRIPTION
I spent a few hours debugging why my hook wasn't running in Travis only
to find out I forgot to set permissions on the file. We should try to
execute the file if it exists and just error out if it exists but is not executable.

[noissue]