### PR TITLE
Fix test stage

### DIFF
--- a/templates/travis/.travis.yml.j2
+++ b/templates/travis/.travis.yml.j2
@@ -57,6 +57,16 @@ after_failure:
   - sudo kubectl logs -l app=pulp-worker --tail=10000
 jobs:
   include:
+{%- if not test_bindings and not docs_test %}
+    # So long as we have a build matrix of only 1 build (via only 1 python
+    # version), we need this as a stub for the default implicit stage also
+    # called "test".
+    # It must be removed once there is more than 1 build, or else there will be
+    # an additional build.
+    # https://github.com/travis-ci/travis-ci/issues/8536
+    # https://github.com/travis-ci/travis-ci/issues/4681
+    - stage: test
+{%- endif %}
     {%- if deploy_to_pypi %}
     - stage: deploy-plugin-to-pypi
       script: bash .travis/publish_plugin_pypi.sh

--- a/templates/travis/.travis.yml.j2
+++ b/templates/travis/.travis.yml.j2
@@ -42,22 +42,21 @@ addons:
       - jq
   # postgres versions provided by el7 RHSCL (lowest supportable version)
   postgresql: '9.6'
+before_install: .travis/before_install.sh
+install: .travis/install.sh
+before_script: .travis/before_script.sh
+script: .travis/script.sh
+after_failure:
+  - http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
+  - sudo docker images
+  - sudo kubectl logs -l name=pulp-operator -c ansible --tail=10000
+  - sudo kubectl logs -l name=pulp-operator -c operator --tail=10000
+  - sudo kubectl logs -l app=pulp-api --tail=10000
+  - sudo kubectl logs -l app=pulp-content --tail=10000
+  - sudo kubectl logs -l app=pulp-resource-manager --tail=10000
+  - sudo kubectl logs -l app=pulp-worker --tail=10000
 jobs:
   include:
-    - stage: test
-      before_install: .travis/before_install.sh
-      install: .travis/install.sh
-      before_script: .travis/before_script.sh
-      script: .travis/script.sh
-      after_failure:
-        - http --timeout 30 --check-status --pretty format --print hb http://localhost:24817/pulp/api/v3/status/
-        - sudo docker images
-        - sudo kubectl logs -l name=pulp-operator -c ansible --tail=10000
-        - sudo kubectl logs -l name=pulp-operator -c operator --tail=10000
-        - sudo kubectl logs -l app=pulp-api --tail=10000
-        - sudo kubectl logs -l app=pulp-content --tail=10000
-        - sudo kubectl logs -l app=pulp-resource-manager --tail=10000
-        - sudo kubectl logs -l app=pulp-worker --tail=10000
     {%- if deploy_to_pypi %}
     - stage: deploy-plugin-to-pypi
       script: bash .travis/publish_plugin_pypi.sh


### PR DESCRIPTION
    Problem: Travis does no builds when the build matrix has 1 build
    
    build matrix for us == Python versions * (docs + bindings + pulp)
    
    Solution: Add a stub implicit job called "test" when there is only
    the TEST=pulp build.
    
    [noissue]
    
    Fixes a regression introduced as part of:
    re: #5004
    https://pulp.plan.io/issues/5004
    "migrate travis plugin-template to installing pulp in containers"

PR also includes a revert for the previous attempted to fix: Which worked for pulp_deb (1 build) but broke other plugins (2+ builds).