### PR TITLE
Problem: CI fails with dependabot, which uses a / in git branch names

### DIFF
--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -17,18 +17,28 @@ pip install -r test_requirements.txt
 
 cd $TRAVIS_BUILD_DIR/../pulpcore/containers/
 
+# Although the tag name is not used outside of this script, we might use it
+# later. And it is nice to have a friendly identifier for it.
+# So we use the branch preferably, but need to replace the "/" with the valid
+# character "_" .
+#
+# Note that there are lots of other valid git branch name special characters
+# that are invalid in image tag names. To try to convert them, this would be a
+# starting point:
+# https://stackoverflow.com/a/50687120
+#
 # If we are on a PR
 if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
-  TAG=$TRAVIS_PULL_REQUEST_BRANCH
+  TAG=$(echo $TRAVIS_PULL_REQUEST_BRANCH | tr / _)
 # For push builds, tag builds, and hopefully cron builds
 elif [ -n "$TRAVIS_BRANCH" ]; then
-  TAG=$TRAVIS_BRANCH
+  TAG=$(echo $TRAVIS_BRANCH | tr / _)
   if [ "$TAG" = "master" ]; then
     TAG=latest
   fi
 else
   # Fallback
-  TAG=$(git rev-parse --abbrev-ref HEAD)
+  TAG=$(git rev-parse --abbrev-ref HEAD | tr / _)
 fi
 
 {% if plugin_name == 'pulpcore' %}


### PR DESCRIPTION
Solution: convert it to an _

[noissue]