### PR TITLE
Problem: Containers are built when publishing to PyPI, etc.

### DIFF
--- a/templates/travis/.travis.yml.j2
+++ b/templates/travis/.travis.yml.j2
@@ -69,6 +69,7 @@ jobs:
 {%- endif %}
     {%- if deploy_to_pypi %}
     - stage: deploy-plugin-to-pypi
+      install: skip
       script: bash .travis/publish_plugin_pypi.sh
       if: tag IS present
     {%- endif %}


### PR DESCRIPTION
Solution: Disable install phase for all deploy & publish steps.

fixes: #5409
Containers are built when testing docs and publishing to PyPI
https://pulp.plan.io/issues/5409

Note: I am only able to partially test this. On Travis mikeded333/pulpcore, the publishing task does not attempt to run the install script. However, it cannot push the docs due to lack of credentials (in Travis env vars.)
https://travis-ci.com/mikedep333/pulpcore/jobs/231988570#L565