### PR TITLE
Add settings.py.j2 for plugin settings

### DIFF
--- a/templates/bootstrap/plugin_name/app/settings.py.j2
+++ b/templates/bootstrap/plugin_name/app/settings.py.j2
@@ -1,0 +1,6 @@
+"""
+Check `Plugin Writer's Guide`_ for more details.
+
+.. _Plugin Writer's Guide:
+    http://docs.pulpproject.org/en/3.0/nightly/plugins/plugin-writer/index.html
+"""


### PR DESCRIPTION
Plugins now have their settings loaded when placed in the file at
``<your plugin>.app.settings.py``.

https://pulp.plan.io/issues/5290
closes #5290