### PR TITLE
Fix YAML generation in .travis.yml and template_config.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ script:
   - ./plugin-template --generate-config --plugin-app-label catdog pulp_catdog
   - mkdir ../pulp_catdog/.travis
   - touch ../pulp_catdog/.travis/test_bindings.py
+  - "echo 'pypi_username: the_pypi_user' >> ../pulp_catdog/template_config.yml"
   - ./plugin-template --all pulp_catdog
   - cd ../pulp_catdog && black --diff --check --exclude docs/conf.py .

--- a/plugin-template
+++ b/plugin-template
@@ -133,8 +133,9 @@ def main():
         else:
             return 2
 
-    # Config key is used by the template_config.yml.j2 template
-    config['config'] = config
+    # Config key is used by the template_config.yml.j2 template to dump
+    # the config. (note: uses .copy() to avoid a self reference)
+    config['config'] = config.copy()
 
     if args.travis or args.all:
         if not config['pypi_username'] and (config['deploy_client_to_pypi'] or \
@@ -157,6 +158,11 @@ def main():
         print("\nAn updated plugin template config written to {path}.\n".format(path=file_path))
 
 
+def to_nice_yaml(data):
+    """Implement a filter for Jinja 2 templates to render human readable YAML."""
+    return yaml.dump(data, indent=2, allow_unicode=True, default_flow_style=False)
+
+
 def write_template_section(config, name, plugin_root_dir, verbose=False):
     """
     Template or copy all files for the section.
@@ -176,7 +182,7 @@ def write_template_section(config, name, plugin_root_dir, verbose=False):
             os.makedirs(necessary_dir_structure)
 
         if relative_path.endswith('.j2'):
-            env.filters['to_yaml'] = yaml.dump
+            env.filters['to_yaml'] = to_nice_yaml
             template = env.get_template(relative_path)
             destination = destination_relative_path[:-len('.j2')]
             write_template_to_file(template, plugin_root_dir, destination, config)

--- a/templates/generate_config/template_config.yml.j2
+++ b/templates/generate_config/template_config.yml.j2
@@ -1,5 +1,4 @@
 # This config represents the latest values used when running the plugin-template. Any settings that
 # were not present before running plugin-template have been added with their default values.
 
-{% for key, value in config.items() %}{% if key != 'config' %}{{ key }}: {{ value }}{% endif %}
-{% endfor %}
+{{ config | to_yaml }}

--- a/templates/travis/.travis.yml.j2
+++ b/templates/travis/.travis.yml.j2
@@ -121,5 +121,5 @@ jobs:
     {%- endif %}
 {%- if travis_notifications %}
 {{ {"notifications": travis_notifications} | to_yaml }}
-{%- endif -%}
+{%- endif %}
 ...


### PR DESCRIPTION
The template did not render YAML in all cases. For example, entries
set to None were rendered as:

```yaml
travis_notifications: None
```

instead of

```yaml
travis_notifications: null
```

When parsing such a file, these entries were set to the string "None".

Additionally, use the PyYAML dump() options to make the output nicer.