### PR TITLE
Travis: Build on tag uses PyPI modules

### DIFF
--- a/templates/travis/.travis/before_install.sh.j2
+++ b/templates/travis/.travis/before_install.sh.j2
@@ -68,27 +68,32 @@ if [ -n "$PULP_PR_NUMBER" ]; then
 fi
 {% endif %}
 
-git clone --depth=1 https://github.com/pulp/pulpcore-plugin.git
+# When building a (release) tag, we don't need the development modules for the
+# build (they will be installed as dependencies of the plugin).
+if [ -z "$TRAVIS_TAG" ]; then
 
-if [ -n "$PULP_PLUGIN_PR_NUMBER" ]; then
-  cd pulpcore-plugin
-  git fetch --depth=1 origin +refs/pull/$PULP_PLUGIN_PR_NUMBER/merge
-  git checkout FETCH_HEAD
-  cd ..
+  git clone --depth=1 https://github.com/pulp/pulpcore-plugin.git
+
+  if [ -n "$PULP_PLUGIN_PR_NUMBER" ]; then
+    cd pulpcore-plugin
+    git fetch --depth=1 origin +refs/pull/$PULP_PLUGIN_PR_NUMBER/merge
+    git checkout FETCH_HEAD
+    cd ..
+  fi
+
+
+  git clone --depth=1 https://github.com/PulpQE/pulp-smash.git
+
+  if [ -n "$PULP_SMASH_PR_NUMBER" ]; then
+    cd pulp-smash
+    git fetch --depth=1 origin +refs/pull/$PULP_SMASH_PR_NUMBER/merge
+    git checkout FETCH_HEAD
+    cd ..
+  fi
+
+  # pulp-smash already got installed via test_requirements.txt
+  pip install --upgrade --force-reinstall ./pulp-smash
 fi
-
-
-git clone --depth=1 https://github.com/PulpQE/pulp-smash.git
-
-if [ -n "$PULP_SMASH_PR_NUMBER" ]; then
-  cd pulp-smash
-  git fetch --depth=1 origin +refs/pull/$PULP_SMASH_PR_NUMBER/merge
-  git checkout FETCH_HEAD
-  cd ..
-fi
-
-# pulp-smash already got installed via test_requirements.txt
-pip install --upgrade --force-reinstall ./pulp-smash
 
 pip install ansible
 

--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -27,10 +27,13 @@ cd $TRAVIS_BUILD_DIR/../pulpcore/containers/
 # starting point:
 # https://stackoverflow.com/a/50687120
 #
+# If we are on a tag
+if [ -n "$TRAVIS_TAG" ]; then
+  TAG=$(echo $TRAVIS_TAG | tr / _)
 # If we are on a PR
-if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
+elif [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
   TAG=$(echo $TRAVIS_PULL_REQUEST_BRANCH | tr / _)
-# For push builds, tag builds, and hopefully cron builds
+# For push builds and hopefully cron builds
 elif [ -n "$TRAVIS_BRANCH" ]; then
   TAG=$(echo $TRAVIS_BRANCH | tr / _)
   if [ "$TAG" = "master" ]; then
@@ -55,7 +58,20 @@ else
   PULP_CERTGUARD=git+https://github.com/pulp/pulp-certguard.git
 fi
 
-cat > vars/vars.yaml << VARSYAML
+if [ -n "$TRAVIS_TAG" ]; then
+  # Install the plugin only and use published PyPI packages for the rest
+  cat > vars/vars.yaml << VARSYAML
+---
+images:
+  - ${PLUGIN}-${TAG}:
+      image_name: $PLUGIN
+      tag: $TAG
+      plugins:
+        - pulp-certguard
+        - ./$PLUGIN
+VARSYAML
+else
+  cat > vars/vars.yaml << VARSYAML
 ---
 images:
   - ${PLUGIN}-${TAG}:
@@ -67,6 +83,7 @@ images:
         - $PULP_CERTGUARD
         - ./$PLUGIN
 VARSYAML
+fi
 
 ansible-playbook build.yaml
 


### PR DESCRIPTION
When building a release on a tag, the Travis build should ensure that the
plugin works with released versions of the pulpcore and pulpcore-plugin
modules. This should catch issues like https://pulp.plan.io/issues/5509.

If the Travis build is for a tag, do not use the master versions of
these modules, but install from PyPI instead.

ref 4386
https://pulp.plan.io/issues/4386