### PR TITLE
Fail if the doc build can't get the api.json schema from Pulp

### DIFF
--- a/templates/docs/docs/Makefile.j2
+++ b/templates/docs/docs/Makefile.j2
@@ -42,7 +42,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	curl -o _static/api.json "http://localhost:24817/pulp/api/v3/docs/api.json?plugin={{ plugin_snake }}&include_html=1"
+	curl --fail -o _static/api.json "http://localhost:24817/pulp/api/v3/docs/api.json?plugin={{ plugin_snake }}&include_html=1"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."


### PR DESCRIPTION
Add "--fail" parameter to the invocation of curl.

[noissue]