### PR TITLE
Set content_origin automatically

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -37,7 +37,7 @@ DEFAULT_SETTINGS = {
     'plugin_name': None,
     'plugin_snake': None,
     'plugin_app_label': None,
-    'pulp_settings': None,
+    'pulp_settings': {"content_origin": "http://($hostname):24816"},
     'pypi_username': None,
     'travis_notifications': None,
 }

--- a/templates/travis/.travis/script.sh.j2
+++ b/templates/travis/.travis/script.sh.j2
@@ -15,6 +15,10 @@ export FUNC_TEST_SCRIPT=$TRAVIS_BUILD_DIR/.travis/func_test_script.sh
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 
 if [ "$TEST" = 'docs' ]; then
+  {% if plugin_name == 'pulpcore' %}
+    export PULP_CONTENT_ORIGIN=http://$(hostname):24816
+  {% endif %}
+
   cd docs
   make html
   cd ..


### PR DESCRIPTION
The plugin_template sets `content_origin` as http://$(hostname):24816`.
This aligns with the current way services are tested on Travis

https://pulp.plan.io/issues/5629
re #5629