### PR TITLE
Only build continuous docs for master

### DIFF
--- a/templates/travis/.travis.yml.j2
+++ b/templates/travis/.travis.yml.j2
@@ -85,7 +85,7 @@ jobs:
       script: bash .travis/publish_docs.sh nightly
       env:
         - TEST=docs
-      if: type != pull_request
+      if: type != pull_request AND branch = master
     {%- endif %}
     {%- if deploy_daily_client_to_rubygems %}
     - stage: publish-daily-client-gem


### PR DESCRIPTION
Dependabot opens PRs against non-master branches which triggers the continuous docs publish stage. We probably should only be publishing docs for master.