### PR TITLE
Allow plugins to enumerate a list of performance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ The following settings are stored in `template_config.yml`.
                         script in the .travis directory of the plugin repository. This script
                         is supposed to exercise the generated client library.
 
-  test-performance      Include a Travis stage that runs a script to test performance.
+  test-performance      Include a Travis stage that runs a script to test performance. If using a
+                        list, a separate stage will run a specific performance test file for each
+                        entry in the list. Otherwise, all performance tests will be run together.
 
   deploy-client-to-pypi Include a Travis stage that publishes a client library to PyPI.
 

--- a/templates/travis/.travis.yml.j2
+++ b/templates/travis/.travis.yml.j2
@@ -116,10 +116,19 @@ jobs:
       if: tag IS present
     {%- endif %}
     {%- if test_performance %}
+      {%- if test_performance is iterable %}
+        {%- for test in test_performance %}
+    - stage: daily-performance-{{test}}-test
+      env:
+        - TEST=performance PERFORMANCE_TEST={{test}}
+      if: type = cron
+        {%- endfor %}
+      {%- else %}
     - stage: daily-performance-test
       env:
         - TEST=performance
       if: type = cron
+      {%- endif %}
     {%- endif %}
 {%- if travis_notifications %}
 {{ {"notifications": travis_notifications} | to_yaml }}

--- a/templates/travis/.travis/script.sh.j2
+++ b/templates/travis/.travis/script.sh.j2
@@ -123,7 +123,11 @@ set -u
 
 if [[ "$TEST" == "performance" ]]; then
   echo "--- Performance Tests ---"
-  pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 {{ plugin_snake }}.tests.performance || show_logs_and_return_non_zero
+  if [[ -n $PERFORMANCE_TEST ]]; then
+    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 {{ plugin_snake }}.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero
+  else
+    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 {{ plugin_snake }}.tests.performance || show_logs_and_return_non_zero
+  fi
   exit
 fi
 


### PR DESCRIPTION
Motivated by https://github.com/pulp/pulp_rpm/pull/1496