### PR TITLE
Problem: We cannot se pulpcore downgrades during plugin installs

### DIFF
--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -91,7 +91,7 @@ VARSYAML
 {%- if plugin_name != 'pulpcore' %}
 fi
 {%- endif %}
-ansible-playbook build.yaml
+ansible-playbook -v build.yaml
 
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image


### PR DESCRIPTION
because the containers build.yaml output is suppressed unless
the ansible task errors.

Solution: Always run `ansible-playbook build.yaml` with -v.