### PR TITLE
Fix unbound variable error

### DIFF
--- a/templates/travis/.travis/script.sh.j2
+++ b/templates/travis/.travis/script.sh.j2
@@ -123,10 +123,10 @@ set -u
 
 if [[ "$TEST" == "performance" ]]; then
   echo "--- Performance Tests ---"
-  if [[ -n $PERFORMANCE_TEST ]]; then
-    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 {{ plugin_snake }}.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero
-  else
+  if [[ -z "$PERFORMANCE_TEST" ]]; then
     pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 {{ plugin_snake }}.tests.performance || show_logs_and_return_non_zero
+  else
+    pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 {{ plugin_snake }}.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero
   fi
   exit
 fi


### PR DESCRIPTION
Repos that don't have PERFORMANCE_TEST set, they get:

```
.travis/script.sh: line 112: PERFORMANCE_TEST: unbound variable
```