### PR TITLE
Check that README is properly renreded.

### DIFF
--- a/templates/travis/.travis/publish_client_pypi.sh.j2
+++ b/templates/travis/.travis/publish_client_pypi.sh.j2
@@ -35,5 +35,6 @@ cd pulp-openapi-generator
 ./generate.sh {{ plugin_snake }} python $VERSION
 cd {{ plugin_snake }}-client
 python setup.py sdist bdist_wheel --python-tag py3
+twine check dist/* || exit 1
 twine upload dist/* -u pulp -p $PYPI_PASSWORD
 exit $?

--- a/templates/travis/.travis/publish_plugin_pypi.sh.j2
+++ b/templates/travis/.travis/publish_plugin_pypi.sh.j2
@@ -7,4 +7,5 @@ set -euv
 pip install twine
 
 python setup.py sdist bdist_wheel --python-tag py3
+twine check dist/* || exit 1
 twine upload dist/* -u {{ pypi_username }} -p $PYPI_PASSWORD


### PR DESCRIPTION
[noissue]

If README is written in reStructuredText, any invalid markup will prevent it from rendering.
`twine check` will report any problems rendering README