### PR TITLE
Problem: plugin-template needs to support both the pulpcore 3.0 and m…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ the root of this new directory. Subsequent uses of the command simply update tha
 The following settings are stored in `template_config.yml`.
 
 ```bash
-  additional_plugins    A list with additional plugin names to be installed on Travis.
+  additional_plugins    A list with additional plugins to be installed on Travis.
+                        Each item in the list is a dict with the following fields:
+                        name: the name of the plugin
+                        branch: the git branch of the plugin
+
+  pulpcore_branch       The branch of pulpcore to check out and install on Travis.
+                        "Required PR" in a commit message will override this.
+                        Your requirements in "setup.py" may inadvertently override this as well.
 
   pypi-username         The username that should be used when uploading packages to PyPI. It
                         is required unless deploy-client-to-pypi and deploy-daily-client-to-pypi

--- a/plugin-template
+++ b/plugin-template
@@ -38,6 +38,7 @@ DEFAULT_SETTINGS = {
     'plugin_snake': None,
     'plugin_app_label': None,
     'pulp_settings': None,
+    'pulpcore_branch': 'master',
     'pypi_username': None,
     'travis_notifications': None,
 }

--- a/templates/travis/.travis/before_install.sh.j2
+++ b/templates/travis/.travis/before_install.sh.j2
@@ -75,7 +75,7 @@ fi
 
 
 {% if plugin_name != 'pulpcore' -%}
-git clone --depth=1 https://github.com/pulp/pulpcore.git
+git clone --depth=1 https://github.com/pulp/pulpcore.git --branch {{ pulpcore_branch }}
 
 if [ -n "$PULP_PR_NUMBER" ]; then
   cd pulpcore

--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -52,10 +52,10 @@ PLUGIN={{ plugin_name }}
 
 # For pulpcore, and any other repo that might check out some plugin PR
 {% for item in additional_plugins %}
-if [ -e $TRAVIS_BUILD_DIR/../{{ item }} ]; then
-  {{ item|upper| replace("-", "_") }}=./{{ item }}
+if [ -e $TRAVIS_BUILD_DIR/../{{ item.name }} ]; then
+  {{ item.name|upper| replace("-", "_") }}=./{{ item.name }}
 else
-  {{ item|upper| replace("-", "_") }}=git+https://github.com/pulp/{{ item }}.git
+  {{ item.name|upper| replace("-", "_") }}=git+https://github.com/pulp/{{ item.name }}.git@{{ item.branch }}
 fi
 {% endfor %}
 
@@ -70,7 +70,7 @@ images:
       plugins:
         - ./$PLUGIN
         {%- for item in additional_plugins %}
-        - {{ item }}
+        - {{ item.name }}
         {%- endfor %}
 VARSYAML
 else
@@ -85,7 +85,7 @@ images:
       plugins:
         - ./$PLUGIN
         {%- for item in additional_plugins %}
-        - ${{ item|upper| replace("-", "_") }}
+        - ${{ item.name|upper| replace("-", "_") }}
         {%- endfor %}
 VARSYAML
 {%- if plugin_name != 'pulpcore' %}


### PR DESCRIPTION
…aster branch for plugins

Solution: specify it in the template_config variable pulpcore_branch
Also reworks additional_plugins into both names and branches
The few plugins currently using additional_plugins must update that
variable in plugin_template.yml

Fixes: #5782
plugin-template needs to support both the pulpcore 3.0 and master branch for plugins
https://pulp.plan.io/issues/5782