### PR TITLE
Fix -z check since shell option -u is enabled

### DIFF
--- a/templates/travis/.travis/script.sh.j2
+++ b/templates/travis/.travis/script.sh.j2
@@ -120,7 +120,7 @@ set -u
 
 if [[ "$TEST" == "performance" ]]; then
   echo "--- Performance Tests ---"
-  if [[ -z "$PERFORMANCE_TEST" ]]; then
+  if [[ -z ${PERFORMANCE_TEST+x} ]]; then
     pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 {{ plugin_snake }}.tests.performance || show_logs_and_return_non_zero
   else
     pytest -vv -r sx --color=yes --pyargs --capture=no --durations=0 {{ plugin_snake }}.tests.performance.test_$PERFORMANCE_TEST || show_logs_and_return_non_zero


### PR DESCRIPTION
The -u option is enabled in script.sh which raises an unbound variable
error when checking for $PERFORMANCE_TEST by wrapping it in a string.
Use +x expansion instead since it doesn't raise an error.