### PR TITLE
Fix pulpcore 3.0 CI

### DIFF
--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -104,6 +104,7 @@ ansible-playbook -v build.yaml
 
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image
+# NOTE: With k3s 1.17, $TAG must be quoted. So that 3.0 does not become 3.
 cat > deploy/crds/pulpproject_v1alpha1_pulp_cr.yaml << CRYAML
 apiVersion: pulpproject.org/v1alpha1
 kind: Pulp
@@ -116,7 +117,7 @@ spec:
     # We have a little over 40GB free on Travis VMs/instances
     size: "40Gi"
   image: {% if plugin_name != 'pulpcore' %}{{ plugin_name }}{% else %}pulp_file{% endif %}
-  tag: $TAG
+  tag: "${TAG}"
   database_connection:
     username: pulp
     password: pulp


### PR DESCRIPTION
Problem with k3s interpreting the 3.0 image tag as 3 due to lack of
quotes.
And therefore thinking the image does not exist (ImagePullBackoff)

[noissue]