### PR TITLE
Remove 'matrix' from Travis template

### DIFF
--- a/templates/travis/.travis.yml.j2
+++ b/templates/travis/.travis.yml.j2
@@ -19,17 +19,6 @@ env:
     - TEST=bindings
     {%- endif %}
 {%- if test_bindings or docs_test %}
-matrix:
-  exclude:
-    {%- if test_bindings %}
-    - python: '3.6'
-      env: TEST=bindings
-    {%- endif %}
-    {%- if docs_test %}
-    - python: '3.6'
-      env: TEST=docs
-    {%- endif %}
-  fast_finish: true
 {%- endif %}
 services:
   - postgresql


### PR DESCRIPTION
The 'matrix' section was causing issues with the new validation on
Travis.

[noissue]