### PR TITLE
Problem: Plugins during Travis tag/release jobs always install the latest…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,22 @@ The following settings are stored in `template_config.yml`.
   additional_plugins    A list with additional plugins to be installed on Travis.
                         Each item in the list is a dict with the following fields:
                         name: the name of the plugin
-                        branch: the git branch of the plugin
+                        branch: the git branch of the plugin. applies to non-tagged Travis jobs, such as PRs & cron jobs.
+                        pip_version_specifier: A pip version specifier for when the gets installed from PyPI.
+                                               Applies to TAGGED (release) jobs.
+                                               See pulpcore_pip_version_specifier, but defaults to undefined, the latest.
 
   pulpcore_branch       The branch of pulpcore to check out and install on Travis.
+                        This only applies to non-tagged Travis jobs, such as PRs & cron jobs.
                         "Required PR" in a commit message will override this.
+                        Your requirements in "setup.py" may inadvertently override this as well.
+
+  pulpcore_pip_version_specifier
+                        A pip version specifier for when pulpcore gets installed from PyPI.
+                        This is only for Travis, and only applies to TAGGED (release) jobs.
+                        An example is "~=3.0.0", which installs the latest 3.0.z,
+                        and is equivalent to `pip install pulpcore~=3.0.0`.
+                        Defaults to null, which installs the latest release from PyPI.
                         Your requirements in "setup.py" may inadvertently override this as well.
 
   pypi_username         The username that should be used when uploading packages to PyPI. It

--- a/plugin-template
+++ b/plugin-template
@@ -41,6 +41,7 @@ DEFAULT_SETTINGS = {
     'plugin_app_label': None,
     'pulp_settings': None,
     'pulpcore_branch': 'master',
+    'pulpcore_pip_version_specifier': None,
     'pypi_username': None,
     'stable_branch': None,
     'travis_notifications': None,

--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -62,10 +62,11 @@ images:
   - {{ plugin_name }}-${TAG}:
       image_name: {{ plugin_name }}
       tag: $TAG
+      pulpcore: pulpcore{{ pulpcore_pip_version_specifier if pulpcore_pip_version_specifier is not none }}
       plugins:
         - ./{{ plugin_name }}
         {%- for item in additional_plugins %}
-        - {{ item.name }}
+        - {{ item.name }}{{ item.pip_version_specifier | default(omit) }}
         {%- endfor %}
 VARSYAML
 else


### PR DESCRIPTION
… PyPI releases of pulpcore & other plugins

Solution: Add pulpcore_pip_version_specifier and additional_plugins.item.pip_version_specifier

fixes: #6149