### PR TITLE
Problem: When pip_version_specifier is set to null, broken config is …

### DIFF
--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -62,11 +62,11 @@ images:
   - {{ plugin_name }}-${TAG}:
       image_name: {{ plugin_name }}
       tag: $TAG
-      pulpcore: pulpcore{{ pulpcore_pip_version_specifier if pulpcore_pip_version_specifier is not none }}
+      pulpcore: pulpcore{{ pulpcore_pip_version_specifier | default(omit,true) }}
       plugins:
         - ./{{ plugin_name }}
         {%- for item in additional_plugins %}
-        - {{ item.name }}{{ item.pip_version_specifier | default(omit) }}
+        - {{ item.name }}{{ item.pip_version_specifier | default(omit,true) }}
         {%- endfor %}
 VARSYAML
 else


### PR DESCRIPTION
…generated

solution: Pass "true" to the 2nd value of the default filters.
Thus:
null value -> evaluates to false ->  defaults to omitting the string.

fixes: #6243