### PR TITLE
Problem: Trailing underscores in branch names breaks CI

### DIFF
--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -36,7 +36,7 @@ elif [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
 # For push builds and hopefully cron builds
 elif [ -n "$TRAVIS_BRANCH" ]; then
   TAG=$(echo $TRAVIS_BRANCH | tr / _)
-  if [ "$TAG" = "master" ]; then
+  if [ "${TAG}" = "master" ]; then
     TAG=latest
   fi
 else
@@ -56,12 +56,13 @@ fi
 {%- if plugin_name != 'pulpcore' %}
 if [ -n "$TRAVIS_TAG" ]; then
   # Install the plugin only and use published PyPI packages for the rest
+  # Quoting ${TAG} ensures Ansible casts the tag as a string.
   cat > vars/vars.yaml << VARSYAML
 ---
 images:
   - {{ plugin_name }}-${TAG}:
       image_name: {{ plugin_name }}
-      tag: $TAG
+      tag: "${TAG}"
       pulpcore: pulpcore{{ pulpcore_pip_version_specifier | default(omit,true) }}
       plugins:
         - ./{{ plugin_name }}
@@ -75,7 +76,7 @@ else
 images:
   - {{ plugin_name }}-${TAG}:
       image_name: {{ plugin_name }}
-      tag: $TAG
+      tag: "${TAG}"
       pulpcore: ./pulpcore
       plugins:
         - ./{{ plugin_name }}
@@ -93,7 +94,7 @@ cat > vars/vars.yaml << VARSYAML
 images:
   - pulp_file-${TAG}:
       image_name: pulp_file
-      tag: $TAG
+      tag: "${TAG}"
       pulpcore: ./pulpcore
       plugins:
         {%- for item in additional_plugins %}
@@ -110,7 +111,7 @@ ansible-playbook -v build.yaml
 
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image
-# NOTE: With k3s 1.17, $TAG must be quoted. So that 3.0 does not become 3.
+# NOTE: With k3s 1.17, ${TAG} must be quoted. So that 3.0 does not become 3.
 cat > deploy/crds/pulpproject_v1alpha1_pulp_cr.yaml << CRYAML
 apiVersion: pulpproject.org/v1alpha1
 kind: Pulp


### PR DESCRIPTION
Solution: Use ${TAG} syntax and quote them. So that they
are cast as strings, not numbers.

fixes: #6405
https://pulp.plan.io/issues/6405
Trailing underscores in branch names breaks CI