### PR TITLE
Problem: Plugins cannot modify the pulp-content containers easily

### DIFF
--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -112,6 +112,8 @@ ansible-playbook -v build.yaml
 cd $TRAVIS_BUILD_DIR/../pulp-operator
 # Tell pulp-perator to deploy our image
 # NOTE: With k3s 1.17, ${TAG} must be quoted. So that 3.0 does not become 3.
+# NOTE: We use 1 pulp-content replica because some plugins need to pass
+# commands to it to modify it, similar to the pulp-api container.
 cat > deploy/crds/pulpproject_v1alpha1_pulp_cr.yaml << CRYAML
 apiVersion: pulpproject.org/v1alpha1
 kind: Pulp
@@ -129,6 +131,8 @@ spec:
     username: pulp
     password: pulp
     admin_password: pulp
+  pulp_content:
+    replicas: 1
 {%- if pulp_settings %}
   pulp_settings:
     {%  for setting, value in pulp_settings.items() %} {{ setting }}: {{ value }}
@@ -154,6 +158,8 @@ if [ "$TEST" = 's3' ]; then
       username: pulp
       password: pulp
       admin_password: pulp
+    pulp_content:
+      replicas: 1
     pulp_settings:
       {% if pulp_settings %}
       {%- for setting, value in pulp_settings.items() -%} {{ setting }}: {{ value }}


### PR DESCRIPTION
because there are 2 of them.

Solution: Use only 1 pulp-content pod.

We can make their # configurable if there is a need in the future.

[noissue]

re: #4664
As a user, I can use a RHSMCertGuard
https://pulp.plan.io/issues/4664