### PR TITLE
Parametrize pulp URL in docs Makefile

### DIFF
--- a/templates/docs/docs/Makefile.j2
+++ b/templates/docs/docs/Makefile.j2
@@ -6,6 +6,7 @@ SPHINXOPTS    = -W -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+PULP_URL      = "http://localhost:24817"
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -42,7 +43,7 @@ clean:
 	-rm -rf $(BUILDDIR)/*
 
 html:
-	curl --fail -o _static/api.json "http://localhost:24817/pulp/api/v3/docs/api.json?plugin={{ plugin_snake }}&include_html=1"
+	curl --fail -o _static/api.json "$(PULP_URL)/pulp/api/v3/docs/api.json?plugin={{ plugin_snake }}&include_html=1"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."

--- a/templates/travis/.travis/script.sh.j2
+++ b/templates/travis/.travis/script.sh.j2
@@ -19,7 +19,7 @@ export PULP_SETTINGS=$TRAVIS_BUILD_DIR/.travis/settings/settings.py
 
 if [ "$TEST" = "docs" ]; then
   cd docs
-  make html
+  make PULP_URL="http://pulp" html
   cd ..
 
   if [ -f $POST_DOCS_TEST ]; then


### PR DESCRIPTION
[noissue]

This ensures that the docs can be built both from within pulplift source
boxes, as well as the Travis pipeline.

The idea came from here: https://github.com/pulp/pulp_deb/pull/166#discussion_r420258701
The implementation came from @mdellweg 

I have successfully tested it on the pulp_deb plugin.