### PR TITLE
Fix bug where nested changelog files weren't being considered

### DIFF
--- a/templates/travis/.travis/release.py.j2
+++ b/templates/travis/.travis/release.py.j2
@@ -1,6 +1,7 @@
 import argparse
 import os
 import textwrap
+from pathlib import Path
 
 from git import Repo
 
@@ -18,9 +19,9 @@ with open(f"{plugin_path}/{{ plugin_name }}/__init__.py") as fp:
 release_version = version["__version__"].replace(".dev", "")
 
 to_close = []
-for filename in os.listdir(f"{plugin_path}/CHANGES"):
-    if filename.split(".")[0].isdigit():
-        to_close.append(filename.split(".")[0])
+for filename in Path(f"{plugin_path}/CHANGES").rglob("*"):
+    if filename.stem.isdigit():
+        to_close.append(filename.stem)
 issues = ",".join(to_close)
 
 helper = textwrap.dedent(


### PR DESCRIPTION
In pulpcore for example, we have entries in CHANGES/plugin_api and
os.listdir() won't return those entries. Fix that bug and also use
pathlib.

[noissue]