### PR TITLE
Improve debugging output in CI

### DIFF
--- a/templates/travis/.travis/build_container.yaml
+++ b/templates/travis/.travis/build_container.yaml
@@ -11,7 +11,6 @@
         dest: Containerfile
 
     - name: "Build pulp image"
-      docker_image:
       # We build from the ../.. (parent dir of pulpcore git repo) Docker build
       # "context" so that repos like pulp-smash are accessible to Docker
       # build. So that PR branches can be used via relative paths.
@@ -20,15 +19,7 @@
       # 1-off-builds and Travis CI purposes (which has no cache across CI runs.)
       # Run build.yaml with -e cache=false if your builds are using outdated
       # layers.
-        name: "{{ image.name }}"
-        tag: "{{ image.tag }}"
-        build:
-          path: "../.."
-          dockerfile: "{{ playbook_dir }}/Containerfile"
-          nocache: "{{ not cache | default(true) | bool }}"
-          pull: false
-        state: present
-        source: build
+      command: "docker build --network host --no-cache={{ not cache | default(true) | bool }} -t {{ image.name }}:{{ image.tag }} -f {{ playbook_dir }}/Containerfile ../.."
 
     - name: "Clean image cache"
       docker_prune:

--- a/templates/travis/.travis/start_container.yaml
+++ b/templates/travis/.travis/start_container.yaml
@@ -67,14 +67,19 @@
         state: present
       when: s3_test | default(false)
 
-    - name: "Wait for Pulp"
-      uri:
-        url: "http://pulp/pulp/api/v3/status/"
-        follow_redirects: none
-      register: result
-      until: result.status == 200
-      retries: 6
-      delay: 5
+    - block:
+        - name: "Wait for Pulp"
+          uri:
+            url: "http://pulp/pulp/api/v3/status/"
+            follow_redirects: none
+          register: result
+          until: result.status == 200
+          retries: 6
+          delay: 5
+      rescue:
+        - name: "Output pulp container log"
+          command: "docker logs pulp"
+          failed_when: true
 
 - hosts: pulp
   gather_facts: false


### PR DESCRIPTION
*Use docker cli to build image.
*Output pulp logs on failed start up.

fixes #6750
https://pulp.plan.io/issues/6750