### PR TITLE
Some tweaks to the commit checking

### DIFF
--- a/.github/workflows/check_commits.yaml
+++ b/.github/workflows/check_commits.yaml
@@ -14,14 +14,20 @@ jobs:
           python-version: 3.8
       - name: Install python dependencies
         run: |
-          pip install requests
+          pip install requests j2cli
+      - name: Generate the validation script
+        shell: bash
+        run: |
+          cd templates
+          redmine_project=pulpcore j2 --undefined travis/.travis/validate_commit_message.py.j2 > ../validate_commit_message.py
+          cd ..
       - name: Check commit message
         env:
           GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
         run: |
           for sha in $(curl $GITHUB_CONTEXT | jq '.[].sha' | sed 's/"//g')
           do
-            python templates/travis/.travis/validate_commit_message.py $sha
+            python validate_commit_message.py $sha
             VALUE=$?
             if [ "$VALUE" -gt 0 ]; then
               exit $VALUE

--- a/templates/travis/.travis/validate_commit_message.py.j2
+++ b/templates/travis/.travis/validate_commit_message.py.j2
@@ -1,3 +1,5 @@
+{% include 'header.j2' %}
+
 import re
 import requests
 import subprocess


### PR DESCRIPTION
I overlooked [another line that uses jinja](https://github.com/pulp/plugin_template/blob/92f12e455d26ec9c863ec0c9e9d678bf6714bc6d/templates/travis/.travis/validate_commit_message.py#L14) so I switched the validate script back to j2 and am using the j2cli tool to generate the file.