### PR TITLE
Remove ``test_file_decriptors`` test

### DIFF
--- a/CHANGES/7452.misc
+++ b/CHANGES/7452.misc
@@ -1,0 +1,2 @@
+Removed the ``test_file_decriptors`` test which was not actually testing Pulp code and was failing
+intermittently.

--- a/templates/bootstrap/plugin_name/tests/functional/api/test_sync.py.j2
+++ b/templates/bootstrap/plugin_name/tests/functional/api/test_sync.py.j2
@@ -86,46 +86,6 @@ class BasicSyncTestCase(unittest.TestCase):
         self.assertEqual(latest_version_href, repo.latest_version_href)
         self.assertDictEqual(get_content_summary(repo.to_dict()), {{ plugin_caps_short }}_FIXTURE_SUMMARY)
 
-    # This test may not make sense for all plugins, but is likely to be useful
-    # for most. Check that it makes sense for yours before enabling it.
-    @unittest.skip("FIXME: plugin writer action required")
-    def test_file_decriptors(self):
-        """Test whether file descriptors are closed properly.
-
-        This test targets the following issue:
-
-        `Pulp #4073 <https://pulp.plan.io/issues/4073>`_
-
-        Do the following:
-
-        1. Check if 'lsof' is installed. If it is not, skip this test.
-        2. Create and sync a repo.
-        3. Run the 'lsof' command to verify that files in the
-           path ``/var/lib/pulp/`` are closed after the sync.
-        4. Assert that issued command returns `0` opened files.
-        """
-        cli_client = cli.Client(self.cfg, cli.echo_handler)
-
-        # check if 'lsof' is available
-        if cli_client.run(("which", "lsof")).returncode != 0:
-            raise unittest.SkipTest("lsof package is not present")
-
-        repo_api = Repositories{{ plugin_camel_short }}Api(self.client)
-        repo = repo_api.create(gen_repo())
-        self.addCleanup(repo_api.delete, repo.pulp_href)
-
-        remote_api = Remotes{{ plugin_camel_short }}Api(self.client)
-        remote = remote_api.create(gen_{{ plugin_app_label }}_remote())
-        self.addCleanup(remote_api.delete, remote.pulp_href)
-
-        repository_sync_data = RepositorySyncURL(remote=remote.pulp_href)
-        sync_response = repo_api.sync(repo.pulp_href, repository_sync_data)
-        monitor_task(sync_response.task)
-
-        cmd = "lsof -t +D {}".format(MEDIA_PATH).split()
-        response = cli_client.run(cmd).stdout
-        self.assertEqual(len(response), 0, response)
-
 
 # Implement sync support before enabling this test.
 @unittest.skip("FIXME: plugin writer action required")


### PR DESCRIPTION
The ``test_file_decriptors`` test was not actually testing Pulp code
and was failing intermittently.

closes #7452