### PR TITLE
Add towncrier to release requirements

### DIFF
--- a/templates/travis/.travis/release_requirements.txt.j2
+++ b/templates/travis/.travis/release_requirements.txt.j2
@@ -1,3 +1,4 @@
 bump2version
 gitpython
 python-redmine
+towncrier


### PR DESCRIPTION
[noissue]

If I am running the release script locally in a python venv, then I need `towncrier` in it.

I am not sure if there is an issue with having this requirement in both `release_requirements.txt` and `doc_requirements.txt` (or what effect this has on Travis pipelines).

What do you think?