### PR TITLE
Adding Makefile

### DIFF
--- a/CHANGES/5107.feature
+++ b/CHANGES/5107.feature
@@ -1,0 +1,1 @@
+Added a Makefile to bootstrap templates to make it easier for plugins to write/run common commands.

--- a/CHANGES/6203.misc
+++ b/CHANGES/6203.misc
@@ -1,0 +1,2 @@
+Adding a ``make test`` command that can be used to run the tests along with all required setup steps
+such as generating bindings.

--- a/CHANGES/6938.feature
+++ b/CHANGES/6938.feature
@@ -1,0 +1,1 @@
+Adding a Makefile to bootstrap template to allow developers to run build-related commands.

--- a/templates/bootstrap/Makefile.j2
+++ b/templates/bootstrap/Makefile.j2
@@ -1,0 +1,50 @@
+COMMIT?=HEAD
+WORKDIR?=.
+VENV?=$(WORKDIR)/.venv
+
+ifeq ($(BIN),)
+ifneq ($(wildcard $(VENV)),)
+BIN=$(VENV)/bin/
+endif
+endif
+
+all: lint test
+
+setup-venv: $(VENV)/bin/activate
+
+$(VENV)/bin/activate:
+	python3 -m venv $(VENV)
+	$(VENV)/bin/pip install -qr dev_requirements.txt
+	$(VENV)/bin/pip install -qr test_requirements.txt
+	$(VENV)/bin/pip install -qe .
+	echo "Set up venv environment at $(VNV)"
+
+lint: lint-black lint-flake8 check-plugin-api check-manifest
+
+lint-black:
+	$(BIN)black --version
+	$(BIN)black --check .
+
+lint-flake8:
+	$(BIN)flake8 --config flake8.cfg
+
+check-commit:
+	python ./.travis/validate_commit_message.py $(COMMIT)
+
+check-plugin-api:
+	./.travis/check_pulpcore_imports.sh
+
+check-manifest:
+	$(BIN)check-manifest
+
+bindings:
+	# TODO: pbindings won't work here. need to recreate this functionality
+	pbindings pulpcore python
+
+test-unit:
+	$(BIN)django-admin test --noinput
+
+test-functional: setup-venv bindings
+	$(BIN)pytest -v -r sx --color=yes --pyargs pulpcore.tests.functional
+
+test: test-unit test-functional

--- a/templates/bootstrap/flake8.cfg
+++ b/templates/bootstrap/flake8.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude = ./docs/*,*/migrations/*
+exclude = ./docs/*,*/migrations/*,.venv/*
 ignore = W503,Q000,Q003,D100,D104,D106,D200,D202,D205,D400,D401,D402,E203
 max-line-length = 100
 

--- a/templates/bootstrap/pyproject.toml.j2
+++ b/templates/bootstrap/pyproject.toml.j2
@@ -70,6 +70,7 @@ ignore = [
     "HISTORY.rst",
     "dev_requirements.txt",
     "doc_requirements.txt",
+    "Makefile",
     "docs/**",
     "flake8.cfg",
     "template_config.yml",

--- a/templates/travis/.travis/before_install.sh.j2
+++ b/templates/travis/.travis/before_install.sh.j2
@@ -44,24 +44,7 @@ pip install -r dev_requirements.txt
 ./.travis/check_commit.sh
 {%- endif %}
 
-{% if black -%}
-# run black separately from flake8 to get a diff
-black --version
-black --check --diff .
-{%- endif %}
-
-# Lint code.
-flake8 --config flake8.cfg
-
-{% if check_manifest -%}
-# check for any files unintentionally left out of MANIFEST.in
-check-manifest
-{%- endif %}
-
-{% if plugin_name != 'pulpcore' -%}
-# check for imports from pulpcore that aren't pulpcore.plugin
-./.travis/check_pulpcore_imports.sh
-{%- endif %}
+make lint
 
 cd ..
 


### PR DESCRIPTION
Adding a Makefile for plugin writers to define common build related tasks such as linting, running tests, etc. Inspiration comes from other python projects such as [dynaconf](https://github.com/rochacbruno/dynaconf/blob/master/Makefile), [celery](https://github.com/celery/celery/blob/master/Makefile), and [rq](https://github.com/rq/rq/blob/master/Makefile).

One of the main goals is to allow developers to run the same checks locally as Travis does by using `make`. 

These commands also create a virtual env that isolates the plugin's dev/test dependencies from other plugins as sharing these deps has led to problems. As one example, flake8 plugins automatically run if they are installed but they can differ from plugin to plugin (for example, some plugins are using flake8-docstrings while others don't). 

I'm hoping this will also serve as a place where plugin writers will be able to define more build type tasks related to releasing, etc.

Feedback welcome.

fixes #6938
fixes #5107