### PR TITLE
Use constant docker tag name

### DIFF
--- a/CHANGES/7799.bugfix
+++ b/CHANGES/7799.bugfix
@@ -1,0 +1,1 @@
+Stopped to derive the docker tag from the branch name.

--- a/templates/travis/.travis/install.sh.j2
+++ b/templates/travis/.travis/install.sh.j2
@@ -17,32 +17,7 @@ pip install -r functest_requirements.txt
 
 cd .travis
 
-# Although the tag name is not used outside of this script, we might use it
-# later. And it is nice to have a friendly identifier for it.
-# So we use the branch preferably, but need to replace the "/" with the valid
-# character "_" .
-#
-# Note that there are lots of other valid git branch name special characters
-# that are invalid in image tag names. To try to convert them, this would be a
-# starting point:
-# https://stackoverflow.com/a/50687120
-#
-# If we are on a tag
-if [ -n "$TRAVIS_TAG" ]; then
-  TAG=$(echo $TRAVIS_TAG | tr / _)
-# If we are on a PR
-elif [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
-  TAG=$(echo $TRAVIS_PULL_REQUEST_BRANCH | tr / _)
-# For push builds and hopefully cron builds
-elif [ -n "$TRAVIS_BRANCH" ]; then
-  TAG=$(echo $TRAVIS_BRANCH | tr / _)
-  if [ "${TAG}" = "master" ]; then
-    TAG=latest
-  fi
-else
-  # Fallback
-  TAG=$(git rev-parse --abbrev-ref HEAD | tr / _)
-fi
+TAG=ci_build
 
 {#- For pulpcore, and any other repo that might check out some plugin PR #}
 {%- for item in additional_plugins %}


### PR DESCRIPTION
CI used to fail if the branch name contained characters not allowed in
container tags.

fixes #7799
https://pulp.plan.io/issues/7799