### PR TITLE
Don't publish docs to the root if not the latest version

### DIFF
--- a/CHANGES/7766.bugfix
+++ b/CHANGES/7766.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where older version of docs would overwrite the latest docs when an older Y stream was released. 

--- a/templates/github/.ci/scripts/docs-builder.py.j2
+++ b/templates/github/.ci/scripts/docs-builder.py.j2
@@ -8,6 +8,9 @@ import os
 import re
 from shutil import rmtree
 import tempfile
+import requests
+import json
+from packaging import version
 
 WORKING_DIR = os.environ["WORKSPACE"]
 
@@ -85,8 +88,17 @@ def main():
 
     ga_build = False
 
+    publish_at_root = False
+
     if (not re.search("[a-zA-Z]", branch) or "post" in branch) and len(branch.split(".")) > 2:
         ga_build = True
+        # Only publish docs at the root if this is the latest version
+        r = requests.get("https://pypi.org/pypi/{{ plugin_dash }}/json")
+        latest_version = version.parse(json.loads(r.text)["info"]["version"])
+        docs_version = version.parse(branch)
+        if latest_version == docs_version:
+            publish_at_root = True
+        # Post releases should use the x.y.z part of the version string to form a path
         if "post" in branch:
             branch = ".".join(branch.split(".")[:-1])
 
@@ -117,22 +129,23 @@ def main():
     elif ga_build:
         # This is a GA build.
         # publish to the root of docs.pulpproject.org
-        version_components = branch.split(".")
-        x_y_version = "{}.{}".format(version_components[0], version_components[1])
-        remote_path_arg = "%s@%s:%s" % (USERNAME, HOSTNAME, SITE_ROOT)
-        rsync_command = [
-            "rsync",
-            "-avzh",
-            "--delete",
-            "--exclude",
-            "en",
-            "--omit-dir-times",
-            local_path_arg,
-            remote_path_arg,
-        ]
-        exit_code = subprocess.call(rsync_command, cwd=docs_directory)
-        if exit_code != 0:
-            raise RuntimeError("An error occurred while pushing docs.")
+        if publish_at_root:
+            version_components = branch.split(".")
+            x_y_version = "{}.{}".format(version_components[0], version_components[1])
+            remote_path_arg = "%s@%s:%s" % (USERNAME, HOSTNAME, SITE_ROOT)
+            rsync_command = [
+                "rsync",
+                "-avzh",
+                "--delete",
+                "--exclude",
+                "en",
+                "--omit-dir-times",
+                local_path_arg,
+                remote_path_arg,
+            ]
+            exit_code = subprocess.call(rsync_command, cwd=docs_directory)
+            if exit_code != 0:
+                raise RuntimeError("An error occurred while pushing docs.")
         # publish to docs.pulpproject.org/en/3.y/
         make_directory_with_rsync(["en", x_y_version])
         remote_path_arg = "%s@%s:%sen/%s/" % (


### PR DESCRIPTION
This patch updates the script that publishes docs to pulpproject.org. The version of the docs being
published is compared to the version of the package on PyPI. If the latest version of the package on
PyPI is equal to the version of the docs being published, the site root is updated with the docs.
Otherwise the docs are published to 3.y and 3.y.z directories.

re: #7766
https://pulp.plan.io/issues/7766