### PR TITLE
Change the version check to use app label

### DIFF
--- a/templates/github/.ci/ansible/start_container.yaml
+++ b/templates/github/.ci/ansible/start_container.yaml
@@ -81,13 +81,22 @@
           command: "docker logs pulp"
           failed_when: true
 
-    - name: "Check version of component being tested"
-      assert:
-        that:
-          - (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] | canonical_semver == (component_version | canonical_semver)
-        fail_msg: |
-          Component {{ component_name }} was expected to be installed in version {{ component_version }}.
-          Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] }}.
+    - block:
+        - name: "Check version of component being tested"
+          assert:
+            that:
+              - (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] | canonical_semver == (component_version | canonical_semver)
+            fail_msg: |
+              Component {{ component_name }} was expected to be installed in version {{ component_version }}.
+              Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] }}.
+      rescue:
+        - name: "Check version of component being tested (legacy)"
+          assert:
+            that:
+              - (result.json.versions | items2dict(key_name="component", value_name="version"))[legacy_component_name] | canonical_semver == (component_version | canonical_semver)
+            fail_msg: |
+              Component {{ legacy_component_name }} was expected to be installed in version {{ component_version }}.
+              Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[legacy_component_name] }}.
 
     - name: "Set pulp password in .netrc"
       copy:

--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -29,7 +29,8 @@ else
 fi
 mkdir .ci/ansible/vars || true
 echo "---" > .ci/ansible/vars/main.yaml
-echo "component_name: {{ plugin_snake }}" >> .ci/ansible/vars/main.yaml
+echo "legacy_component_name: {{ plugin_snake }}" >> .ci/ansible/vars/main.yaml
+echo "component_name: {{ plugin_app_label }}" >> .ci/ansible/vars/main.yaml
 echo "component_version: '${COMPONENT_VERSION}'" >> .ci/ansible/vars/main.yaml
 
 export PRE_BEFORE_INSTALL=$PWD/.github/workflows/scripts/pre_before_install.sh


### PR DESCRIPTION
A change in pulpcore (status API) requires us to change the version test
to use the app label instead of the repository name.
Along with this change we introduce a legacy lookup as a fallback to not
break all CI at the same time.

[noissue]