### PR TITLE
Wait 1 minute for the pulp container

### DIFF
--- a/templates/github/.ci/ansible/start_container.yaml
+++ b/templates/github/.ci/ansible/start_container.yaml
@@ -74,7 +74,7 @@
             follow_redirects: none
           register: result
           until: result.status == 200
-          retries: 6
+          retries: 12
           delay: 5
       rescue:
         - name: "Output pulp container log"


### PR DESCRIPTION
30s is not enough sometimes.
It gives false negatives in CI, and prompts for manual rerun.

[noissue]