### PR TITLE
Allow default branches not named master

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The following settings are stored in `template_config.yml`.
 
   plugin_dash_short     Suppose our plugin is named 'pulp_test', then this is 'test'
 
+  plugin_default_branch The default branch in your plugin repo, defaults to 'master'.
+
   plugin_name           Suppose our plugin is named 'pulp_test', then this is 'pulp_test'
 
   plugin_snake          Suppose our plugin is named 'pulp_test', then this is 'pulp_test'

--- a/plugin-template
+++ b/plugin-template
@@ -37,6 +37,7 @@ DEFAULT_SETTINGS = {
     'plugin_caps_short': None,
     'plugin_dash': None,
     'plugin_dash_short': None,
+    'plugin_default_branch': 'master',
     'plugin_name': None,
     'plugin_snake': None,
     'publish_docs_to_pulpprojectdotorg': False,

--- a/templates/bootstrap/CONTRIBUTING.rst.j2
+++ b/templates/bootstrap/CONTRIBUTING.rst.j2
@@ -8,7 +8,7 @@ To contribute to the ``{{ plugin_dash }}`` package follow this process:
 3. Make sure all tests passed
 4. Add a file into CHANGES folder (Changelog update).
 5. Commit changes to own ``{{ plugin_snake }}`` clone
-6. Make pull request from github page for your clone against master branch
+6. Make pull request from github page for your clone against {{ plugin_defualt_branch }} branch
 
 
 .. _changelog-update:

--- a/templates/docs/docs/conf.py.j2
+++ b/templates/docs/docs/conf.py.j2
@@ -43,7 +43,7 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
+# The top level toctree document.
 master_doc = 'index'
 
 # General information about the project.

--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -48,7 +48,7 @@ if [[ -n $(echo -e $COMMIT_MSG | grep -P "Required PR:.*" | grep -v "https") ]];
   exit 1
 fi
 
-if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "${BRANCH_BUILD}" = "1" -a "${BRANCH}" != "master" ]
+if [ "$GITHUB_EVENT_NAME" = "pull_request" ] || [ "${BRANCH_BUILD}" = "1" -a "${BRANCH}" != "{{ plugin_default_branch }}" ]
 then
 {%- for repository in ["pulpcore", "pulp-smash", "pulp-openapi-generator", "pulp-cli"] + additional_plugins | map(attribute="name") | list %}
   export {{ repository | upper | replace("-", "_") }}_PR_NUMBER=$(echo $COMMIT_MSG | grep -oP 'Required\ PR:\ https\:\/\/github\.com\/pulp\/{{ repository }}\/pull\/(\d+)' | awk -F'/' '{print $7}')


### PR DESCRIPTION
[noissue]

In `pulp_deb` the default branch is called `main`.
This change would allow me to set this in the plugin `template_config.yml` file, to avoid accidentally breaking the CI by adding `master` to it.