### PR TITLE
Added issue_tracker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ The following settings are stored in `template_config.yml`.
   docker_fixtures       In Github Actions, use the pulp-fixtures docker container to serve up
                         fixtures instead of using fedorapeople.org.
 
+  issue_tracker         Which issue tracker the project will use. Valid values are 'redmine' and 'github'.
+                        To switch from Redmine to GitHub use the --migrate-github-issues option.
+
   docs_test             Include a CI build for testing the 'make html' command for sphinx docs.
 
   plugin_app_label      Suppose our plugin is named 'pulp_test', then this is 'test'

--- a/plugin-template
+++ b/plugin-template
@@ -30,6 +30,7 @@ DEFAULT_SETTINGS = {
     'deploy_to_pypi': True,
     'docker_fixtures': False,
     'docs_test': True,
+    'issue_tracker': 'redmine',
     'plugin_app_label': None,
     'plugin_camel': None,
     'plugin_camel_short': None,
@@ -117,6 +118,10 @@ def main():
                             Include more output.
 
                         '''))
+    parser.add_argument('--migrate-github-issues', action='store_true',
+                        help=textwrap.dedent('''\
+                            Migrate plugin's issue checker CI/CD from Redmine to GitHub
+                        '''))
     args = parser.parse_args()
 
 
@@ -164,6 +169,13 @@ def main():
     # Config key is used by the template_config.yml.j2 template to dump
     # the config. (note: uses .copy() to avoid a self reference)
     config['config'] = config.copy()
+
+    if args.migrate_github_issues:
+        if config['issue_tracker'] == 'github':
+            print(f"{args.plugin_name} is already using GitHub as the issue tracker")
+            return 2
+        migrate_github_issues(config, plugin_root_dir, verbose=args.verbose)
+        return 0
 
     if args.github or args.all:
         if not config['pypi_username'] and (config['deploy_client_to_pypi'] or \
@@ -307,6 +319,31 @@ def check_for_deprecated_files(plugin_root_dir):
     if not files_found:
         print("No deprecated files found.")
 
+
+def migrate_github_issues(config, plugin_root_dir, verbose=False):
+    """Moves the plugin's issue checker CI/CD off of Redmine and onto GitHub"""
+    print("Updating template_config.yml and templating ci section")
+    name = config['plugin_name']
+    redmine = config['redmine_project']
+    if not redmine:
+        print("Redmine project name not set. Please set 'redmine_project' in template_config.yml"
+              " and rerun this command")
+        return 2
+    config['issue_tracker'] = 'github'
+    config['redmine_project'] = None
+    config['update_redmine'] = False
+    config.pop('config')
+    config['config'] = config.copy()
+    write_template_section(config, "generate_config", plugin_root_dir, verbose=verbose)
+    write_template_section(config, "github", plugin_root_dir, verbose=verbose)
+    print("Updating pyproject.toml to point to GitHub issues\n")
+    search_string = "pulp.plan.io"
+    replace_string = f"github.com\/pulp\/{name}"
+    os.system(f"sed -i 's/{search_string}/{replace_string}/' {plugin_root_dir}/pyproject.toml")
+    print(f"Please check the Pulp-CI PR processor (https://git.io/Jtsz5) and remove {name}"
+          f" if present\n")
+    print(f"Don't forget to migrate current issues from https://pulp.plan.io/projects/{redmine}"
+          f" and remove the repo from the project settings\n")
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/templates/bootstrap/README.md.j2
+++ b/templates/bootstrap/README.md.j2
@@ -8,10 +8,15 @@ For more information, please see the [documentation](docs/index.rst) or the [Pul
 How to File an Issue
 --------------------
 
+{% if issue_tracker=='redmine' %}
 Visit [our tracker](https://pulp.plan.io/projects/{{ redmine_project }}/issues/new) to file a {{ plugin_dash }} issue.
+{% elif issue_tracker=='github' %}
+File through this project's GitHub issues and appropriate labels.
+{% endif %}
 
 > **WARNING** Is this security related? If so, please follow the [Security Disclosures](https://docs.pulpproject.org/pulpcore/bugs-features.html#security-bugs) procedure.
 
+{% if issue_tracker=='redmine' %}
 Please set **only the fields in this table**. See [Redmine Fields](https://docs.pulpproject.org/pulpcore/bugs-features.html#redmine-fields) for more detailed
 descriptions of all the fields and how they are used.
 
@@ -24,3 +29,4 @@ descriptions of all the fields and how they are used.
 | Version | The version of {{ plugin_dash }} that you discovered the issue. |
 | OS | Please select your operating system. |
 | Tags | For searching. Select 0 or many, best judgement. |
+{% endif %}

--- a/templates/bootstrap/pyproject.toml.j2
+++ b/templates/bootstrap/pyproject.toml.j2
@@ -11,7 +11,11 @@ filename = "CHANGES.rst"
 directory = "CHANGES/"
 title_format = "{version} ({project_date})"
 template = "CHANGES/.TEMPLATE.rst"
+{% if issue_tracker=='redmine' %}
 issue_format = "`#{issue} <https://pulp.plan.io/issues/{issue}>`_"
+{% elif issue_tracker=='github' %}
+issue_format = "`#{issue} <https://github.com/pulp/{{ plugin_name }}/issues/{issue}>`_"
+{% endif %}
 
     [[tool.towncrier.type]]
         directory = "feature"

--- a/templates/github/.ci/scripts/release.py.j2
+++ b/templates/github/.ci/scripts/release.py.j2
@@ -1,16 +1,17 @@
 {% include 'header.j2' %}
 
 import argparse
-import json
 import re
 import os
 import textwrap
-from collections import defaultdict
-from pathlib import Path
 
 from git import Repo
+{% if issue_tracker=='redmine' %}
+from collections import defaultdict
+from pathlib import Path
 from redminelib import Redmine
 from redminelib.exceptions import ResourceAttrError
+import json
 
 
 REDMINE_URL = "https://pulp.plan.io"
@@ -60,7 +61,7 @@ def validate_redmine_data(redmine_query_url, redmine_issues):
         raise RuntimeError("\n".join(error_messages))
 
     return milestone_url
-
+{% endif %}
 
 release_path = os.path.dirname(os.path.abspath(__file__))
 plugin_path = release_path.split("/.ci")[0]
@@ -75,7 +76,7 @@ with open(f"{plugin_path}/setup.py") as fp:
         raise RuntimeError("Could not detect existing version ... aborting.")
 release_version = version.replace(".dev", "")
 
-
+{% if issue_tracker=='redmine' %}
 issues_to_close = set()
 for filename in Path(f"{plugin_path}/CHANGES").rglob("*"):
     if filename.stem.isdigit():
@@ -85,7 +86,7 @@ for filename in Path(f"{plugin_path}/CHANGES").rglob("*"):
 issues = ",".join(issues_to_close)
 redmine_final_query = f"{REDMINE_QUERY_URL}{issues}"
 milestone_url = validate_redmine_data(redmine_final_query, issues_to_close)
-
+{% endif %}
 helper = textwrap.dedent(
     """\
         Start the release process.
@@ -159,10 +160,14 @@ git.add(f"{plugin_path}/docs/conf.py")
 git.add(f"{plugin_path}/setup.py")
 git.add(f"{plugin_path}/requirements.txt")
 git.add(f"{plugin_path}/.bumpversion.cfg")
+{% if issue_tracker=='redmine' %}
 git.commit(
     "-m",
     f"Release {release_version}\n\nRedmine Query: {redmine_final_query}\n{milestone_url}",
 )
+{% else %}
+git.commit("-m", f"Release {release_version}")
+{% endif %}
 
 sha = repo.head.object.hexsha
 short_sha = git.rev_parse(sha, short=7)
@@ -193,6 +198,8 @@ git.add(f"{plugin_path}/requirements.txt")
 git.add(f"{plugin_path}/.bumpversion.cfg")
 git.commit("-m", f"Bump to {new_dev_version}\n\n[noissue]")
 
+{% if issue_tracker=='redmine' %}
 print(f"\n\nRedmine query of issues to close:\n{redmine_final_query}")
+{% endif %}
 print(f"Release commit == {short_sha}")
 print(f"All changes were committed on branch: release_{release_version}")

--- a/templates/github/.ci/scripts/validate_commit_message.py.j2
+++ b/templates/github/.ci/scripts/validate_commit_message.py.j2
@@ -1,11 +1,33 @@
 {% include 'header.j2' %}
 
 import re
+{% if issue_tracker=='redmine' %}
 import requests
+{% endif %}
 import subprocess
 import sys
 from pathlib import Path
+{% if issue_tracker=='github' %}
+from github import Github
 
+KEYWORDS = ["fixes", "closes"]
+NO_ISSUE = "[noissue]"
+CHANGELOG_EXTS = [".feature", ".bugfix", ".doc", ".removal", ".misc", ".deprecation"]
+
+sha = sys.argv[1]
+message = subprocess.check_output(["git", "log", "--format=%B", "-n 1", sha]).decode("utf-8")
+
+g = Github()
+repo = g.get_repo("pulp/{{ plugin_name }}")
+
+
+def __check_status(issue):
+    gi = repo.get_issue(int(issue))
+    if gi.pull_request:
+        sys.exit(f"Error: issue #{issue} is a pull request.")
+    if gi.closed_at:
+        sys.exit(f"Error: issue #{issue} is closed.")
+{% else %}
 KEYWORDS = ["fixes", "closes", "re", "ref"]
 NO_ISSUE = "[noissue]"
 STATUSES = ["NEW", "ASSIGNED", "POST", "MODIFIED"]
@@ -33,7 +55,7 @@ def __check_status(issue):
         project_json = requests.get(f"{REDMINE_URL}/projects/{project_id}.json").json()
         if project_json["project"]["identifier"] != project:
             sys.exit(f"Error: issue {issue} is not in the {project} project.")
-
+{% endif %}
 
 def __check_changelog(issue):
     matches = list(Path("CHANGES").rglob(f"{issue}.*"))

--- a/templates/github/.github/workflows/scripts/check_commit.sh.j2
+++ b/templates/github/.github/workflows/scripts/check_commit.sh.j2
@@ -9,6 +9,9 @@ set -euv
 
 echo ::group::REQUESTS
 pip3 install requests
+{% if issue_tracker=='github' %}
+pip3 install pygithub
+{% endif %}
 echo ::endgroup::
 
 for sha in $(curl $GITHUB_CONTEXT | jq '.[].sha' | sed 's/"//g')


### PR DESCRIPTION
[noissue]

Adding new config option, plus a --migrate-github-issues command to help plugins move off of Redmine in the future. This PR follows the instructions @daviddavis came up with here: https://hackmd.io/y3AnY_bCQCODemWQk2bfoQ?both. I'm going to test this out soon on Pulp Python after its next release.