### PR TITLE
Properly handle duplicate issues in release script

### DIFF
--- a/templates/github/.ci/scripts/release.py.j2
+++ b/templates/github/.ci/scripts/release.py.j2
@@ -76,12 +76,11 @@ with open(f"{plugin_path}/setup.py") as fp:
 release_version = version.replace(".dev", "")
 
 
-issues_to_close = []
+issues_to_close = set()
 for filename in Path(f"{plugin_path}/CHANGES").rglob("*"):
     if filename.stem.isdigit():
         issue = filename.stem
-        issue_url = f"{REDMINE_URL}/issues/{issue}.json"
-        issues_to_close.append(issue)
+        issues_to_close.add(issue)
 
 issues = ",".join(issues_to_close)
 redmine_final_query = f"{REDMINE_QUERY_URL}{issues}"


### PR DESCRIPTION
It's possible that an issue has two changelog entries which leads to
dupes in the issues_to_close list.

[noissue]