### PR TITLE
Appended a missing slash to the token server path.

### DIFF
--- a/templates/github/.ci/ansible/settings.py.j2.copy
+++ b/templates/github/.ci/ansible/settings.py.j2.copy
@@ -3,7 +3,7 @@ ANSIBLE_API_HOSTNAME = "http://pulp:80"
 ANSIBLE_CONTENT_HOSTNAME = "http://pulp:80/pulp/content"
 PRIVATE_KEY_PATH = "/etc/pulp/certs/token_private_key.pem"
 PUBLIC_KEY_PATH = "/etc/pulp/certs/token_public_key.pem"
-TOKEN_SERVER = "http://pulp:80/token"
+TOKEN_SERVER = "http://pulp:80/token/"
 TOKEN_SIGNATURE_ALGORITHM = "ES256"
 
 {% if pulp_settings %}


### PR DESCRIPTION
This misconfiguration forces the client to perform redirects from `/token` to `/token/`.
The requests library drops custom authentication headers during redirects and replaces
them with the configuration from `.netrc`. Because of that, the tests that query the
token server always sent requests with `admin` credentials.

[noissue]