### PR TITLE
Add status api fallbacks to the version checks

### DIFF
--- a/templates/github/.ci/scripts/publish_client_gem.sh.j2
+++ b/templates/github/.ci/scripts/publish_client_gem.sh.j2
@@ -13,7 +13,7 @@ echo "---
 :rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
 sudo chmod 600 ~/.gem/credentials
 
-export REPORTED_VERSION=$(http pulp/pulp/api/v3/status/ | jq --arg plugin {{ plugin_app_label }} -r '.versions[] | select(.component == $plugin) | .version')
+export REPORTED_VERSION=$(http pulp/pulp/api/v3/status/ | jq --arg plugin {{ plugin_app_label }} --arg legacy_plugin {{ plugin_snake }} -r '.versions[] | select(.component == $plugin or .component == $legacy_plugin) | .version')
 export DESCRIPTION="$(git describe --all --exact-match `git rev-parse HEAD`)"
 if [[ $DESCRIPTION == 'tags/'$REPORTED_VERSION ]]; then
   export VERSION=${REPORTED_VERSION}

--- a/templates/github/.ci/scripts/publish_client_pypi.sh.j2
+++ b/templates/github/.ci/scripts/publish_client_pypi.sh.j2
@@ -9,7 +9,7 @@ cd "$(dirname "$(realpath -e "$0")")"/../..
 
 pip install twine
 
-export REPORTED_VERSION=$(http pulp/pulp/api/v3/status/ | jq --arg plugin {{ plugin_app_label }} -r '.versions[] | select(.component == $plugin) | .version')
+export REPORTED_VERSION=$(http pulp/pulp/api/v3/status/ | jq --arg plugin {{ plugin_app_label }} --arg legacy_plugin {{ plugin_snake }} -r '.versions[] | select(.component == $plugin or .component == $legacy_plugin) | .version')
 export DESCRIPTION="$(git describe --all --exact-match `git rev-parse HEAD`)"
 if [[ $DESCRIPTION == 'tags/'$REPORTED_VERSION ]]; then
   export VERSION=${REPORTED_VERSION}

--- a/templates/github/.ci/scripts/publish_plugin_pypi.sh.j2
+++ b/templates/github/.ci/scripts/publish_plugin_pypi.sh.j2
@@ -8,7 +8,8 @@ cd "$(dirname "$(realpath -e "$0")")"/../..
 set -euv
 
 export VERSION=$(http pulp/pulp/api/v3/status/ | jq --arg plugin {{ plugin_app_label }} -r '.versions[] | select(.component == $plugin) | .version')
-export response=$(curl --write-out %{http_code} --silent --output /dev/null https://pypi.org/project/{{ plugin_dash }}-client/$VERSION/)
+export VERSION=$(http pulp/pulp/api/v3/status/ | jq --arg plugin {{ plugin_app_label }} --arg legacy_plugin {{ plugin_snake }} -r '.versions[] | select(.component == $plugin or .component == $legacy_plugin) | .version')
+export response=$(curl --write-out %{http_code} --silent --output /dev/null https://pypi.org/project/{{ plugin_dash }}/$VERSION/)
 if [ "$response" == "200" ];
 then
   echo "{{ plugin_name }} $VERSION has already been released. Skipping."


### PR DESCRIPTION
On old release branches we still need to perform releases with
pulpcore<3.11 which provides the version info by plugin_snake instead of
app_label.

[noissue]