### PR TITLE
Update manifest

### DIFF
--- a/templates/bootstrap/COPYRIGHT
+++ b/templates/bootstrap/COPYRIGHT
@@ -1,0 +1,10 @@
+Copyright © 2017 Pulp Project developers.
+
+This software is licensed to you under the GNU General Public
+License as published by the Free Software Foundation; either version
+2 of the License (GPLv2) or (at your option) any later version.
+There is NO WARRANTY for this software, express or implied,
+including the implied warranties of MERCHANTABILITY,
+NON-INFRINGEMENT, or FITNESS FOR A PARTICULAR PURPOSE. You should
+have received a copy of GPLv2 along with this software; if not, see
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.

--- a/templates/bootstrap/MANIFEST.in
+++ b/templates/bootstrap/MANIFEST.in
@@ -1,7 +1,7 @@
-include LICENSE
-include requirements.txt
-include pyproject.toml
 include CHANGES.rst
 include COMMITMENT
 include functest_requirements.txt
+include LICENSE
+include pyproject.toml
+include requirements.txt
 include unittest_requirements.txt

--- a/templates/bootstrap/MANIFEST.in
+++ b/templates/bootstrap/MANIFEST.in
@@ -1,5 +1,6 @@
 include CHANGES.rst
 include COMMITMENT
+include COPYRIGHT
 include functest_requirements.txt
 include LICENSE
 include pyproject.toml


### PR DESCRIPTION
Two small commits: One makes the entries in `MANIFEST.in` use alphabetic order, the second adds the `COPYRIGHT` file to the list.

If `COPYRIGHT` should not be in the `MANIFEST.in` file, please explain why. :wink: 