### PR TITLE
Allow commit messages to be case insensitive

### DIFF
--- a/templates/github/.ci/scripts/cherrypick.sh.j2
+++ b/templates/github/.ci/scripts/cherrypick.sh.j2
@@ -18,9 +18,9 @@ issue="$2"
 backport="$3"
 commit_message=$(git log --format=%B -n 1 $commit)
 
-if ! echo $commit_message | grep -q "\[noissue\]"
+if ! echo $commit_message | tr '[:upper:]' '[:lower:]' | grep -q "\[noissue\]"
 then
-  if ! echo $commit_message | grep -q -E "(fixes|closes).*#$issue"
+  if ! echo $commit_message | tr '[:upper:]' '[:lower:]' | grep -q -E "(fixes|closes).*#$issue"
   then
     echo "Error: issue $issue not detected in commit message." && exit 1
   fi


### PR DESCRIPTION
Currently this failed on:

`.ci/scripts/cherrypick.sh 3669a65d07278a3c45505001589 8711 8712`

[noissue]