### PR TITLE
Don't run CI on branch push

### DIFF
--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -5,9 +5,6 @@ on:
   pull_request:
     branches:
       - '*'
-  push:
-    branches:
-      - '*'
 
 jobs:
 


### PR DESCRIPTION
The marginal utility of running tests on branches immediately after
merging a PR where the tests were already run is not zero, but it is
very low. Let's reduce our CI consumption by getting rid of the
duplication. Nightly builds are probably sufficient for the small
likelihood of post-merge errors.

[noissue]