### PR TITLE
Move ruby install to later in nightly workflow

### DIFF
--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -38,11 +38,6 @@ jobs:
         with:
           python-version: "3.7"
 
-      - uses: actions/setup-ruby@v1
-        if: {{ "${{ env.TEST == 'bindings' || env.TEST == 'generate-bindings' }}" }}
-        with:
-          ruby-version: "2.6"
-
       - name: Install httpie
         run: |
           echo ::group::HTTPIE
@@ -55,6 +50,11 @@ jobs:
       - name: Before Install
         run: .github/workflows/scripts/before_install.sh
         shell: bash
+
+      - uses: ruby/setup-ruby@v1
+        if: {{ "${{ env.TEST == 'bindings' || env.TEST == 'generate-bindings' }}" }}
+        with:
+          ruby-version: "2.6"
 
       - name: Install
         run: .github/workflows/scripts/install.sh


### PR DESCRIPTION
For some reasy this action would always get skipped when it was run
right after the action that installs Python.

[noissue]