### PR TITLE
Also show flake8 version in CI pipeline

### DIFF
--- a/.github/workflows/bootstrap.yaml
+++ b/.github/workflows/bootstrap.yaml
@@ -50,7 +50,9 @@ jobs:
 
       # Lint code.
       - name: Run flake8
-        run: flake8 --config flake8.cfg
+        run: |
+          flake8 --version
+          flake8 --config flake8.cfg
 
       # check for any files unintentionally left out of MANIFEST.in
       - name: Check manifest


### PR DESCRIPTION
[noissue]

We already have this for black. It can help understand why a locally installed flake8 did not alert to the same things as the one in the CI.