### PR TITLE
Adds an optional 'before_script' parameter to the release worklow.

### DIFF
--- a/CHANGES/433.feature
+++ b/CHANGES/433.feature
@@ -1,0 +1,1 @@
+Added an optional 'before_script' parameter to the release workflow.

--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -7,6 +7,11 @@ on:
       release:
         description: "Release tag (e.g. 3.2.1)"
         required: true
+      before_script:
+        description: |
+          Bash code to run before script.sh is executed. This should only be used when re-running
+          a workflow to correct some aspect of the docs. e.g.: git checkout origin/3.14 CHANGES.rst
+        required: false
 
 env:
   RELEASE_WORKFLOW: true
@@ -140,6 +145,10 @@ jobs:
       - name: Install Ruby client
         if: {{ "${{ env.TEST == 'bindings' || env.TEST == 'generate-bindings' }}" }}
         run: .github/workflows/scripts/install_ruby_client.sh
+
+      - name: Additional before_script
+        run: {{ "${{ github.event.inputs.before_script }}" }}
+        shell: bash
 
       - name: Script
         if: {{ "${{ env.TEST != 'generate-bindings' }}" }}


### PR DESCRIPTION
This parameter should be used when re-running a release workflow in
order to publish updated docs.

fixes: #433