### PR TITLE
Fix `After failure` step

### DIFF
--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -136,7 +136,7 @@ jobs:
         shell: bash
 
       - name: After failure
-        if: failure()
+        if: {{ "${{ failure() }}" }} 
         run: |
           echo "Need to debug? Please check: https://github.com/marketplace/actions/debugging-with-tmate"
           http --timeout 30 --check-status --pretty format --print hb http://pulp/pulp/api/v3/status/ || true
@@ -225,7 +225,7 @@ jobs:
         run: .github/workflows/scripts/script.sh
 
       - name: After failure
-        if: failure()
+        if: {{ "${{ failure() }}" }}
         run: |
           http --timeout 30 --check-status --pretty format --print hb http://pulp/pulp/api/v3/status/ || true
           docker images || true


### PR DESCRIPTION
Without this fix, CI won't fail but it also won't perform the `after failure` step.
It's a very useful step, since the pulp logs are there.

[noissue]