### PR TITLE
Use main as default for default branch

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -43,7 +43,7 @@ DEFAULT_SETTINGS = {
     'plugin_caps_short': None,
     'plugin_dash': None,
     'plugin_dash_short': None,
-    'plugin_default_branch': 'master',
+    'plugin_default_branch': 'main',
     'plugin_name': None,
     'plugin_snake': None,
     'publish_docs_to_pulpprojectdotorg': False,


### PR DESCRIPTION
The standard default branch name in git and github is main.

[noissue]