### PR TITLE
Add empty line before noissue

### DIFF
--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -318,5 +318,6 @@ jobs:
           body: '[noissue]'
           commit-message: |
             Building changelog for {{ "${{ github.event.inputs.release }}" }}
+
             [noissue]
           delete-branch: true


### PR DESCRIPTION
[noissue]

Not tested, but I noticed my release workflow produced a commit message without the empty line.