### PR TITLE
Allow custom workflow name

### DIFF
--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -1,6 +1,6 @@
 {% include 'header.j2' %}
 ---
-name: Pulp CI
+name: {{ plugin_camel_short | default("Pulp") }} CI
 on: {{ ci_trigger | default("{pull_request: {branches: ['*']}}") }}
 jobs:
 

--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -1,6 +1,6 @@
 {% include 'header.j2' %}
 ---
-name: Pulp Nightly CI/CD
+name: {{ plugin_camel_short | default("Pulp") }} Nightly CI/CD
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string


### PR DESCRIPTION
I am not sure if there is a need for using `Pulp CI` on every plugin but here is a proposal.

Right now the workflow in a plugin is named `Pulp CI` this changes that
label to be `Plugin CI` e.g: `Galaxy CI`

Before

![Screenshot_2021-08-03_21-35-55](https://user-images.githubusercontent.com/458654/128082383-a19e7366-cfc9-4278-9a73-30087f1dc59a.png)

After
![Screenshot_2021-08-03_21-36-22](https://user-images.githubusercontent.com/458654/128082392-748d4477-a6e7-4fe0-aca8-5a9f17a54a72.png)


[noissue]