### PR TITLE
Change the cherry pick changelog branch name

### DIFF
--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -312,7 +312,7 @@ jobs:
         with:
           committer: {{  'pulpbot <pulp-infra@redhat.com>' }}
           author: {{  'pulpbot <pulp-infra@redhat.com>' }}
-          branch: {{ "${{ github.event.inputs.release }}" }}-changelog
+          branch: changelog/{{ "${{ github.event.inputs.release }}" }}
           base: {{ plugin_default_branch }}
           title: 'Building changelog for {{ "${{ github.event.inputs.release }}" }}'
           body: '[noissue]'


### PR DESCRIPTION
Most repos have branch protection rules against `[0-9]*.[0-9]*` which
prevents us from deleting x.x.x-changelog branches after they are
merged.

[noissue]