### PR TITLE
Allow UpdateCI to be customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ The following settings are stored in `template_config.yml`.
                         The username and token are used to push the Changelog and version bump commits
                         created by the release workflow. The default is 'pulpbot'.
 
+  release_email         The email address associated with the release_user.
+
+  noissue_marker        A string that is used to mark a commit as not attached to an issue.
+
   sync_ci               Enables a nightly workflow to update the CI files.
 
   test_bindings         Include a job that runs a script to test generated client

--- a/plugin-template
+++ b/plugin-template
@@ -57,6 +57,8 @@ DEFAULT_SETTINGS = {
     "python_version": "3.8",
     "redmine_project": None,
     "release_user": "pulpbot",
+    "release_email": "pulp-infra@redhat.com",
+    "noissue_marker": "[noissue]",
     "sync_ci": True,
     "test_bindings": True,
     "test_cli": False,

--- a/templates/github/.github/workflows/create-branch.yml.j2
+++ b/templates/github/.github/workflows/create-branch.yml.j2
@@ -62,8 +62,8 @@ jobs:
       - name: Make a PR with version bump
         uses: peter-evans/create-pull-request@v3
         with:
-          committer: {{  'pulpbot <pulp-infra@redhat.com>' }}
-          author: {{  'pulpbot <pulp-infra@redhat.com>' }}
+          committer: {{release_user}} <{{ release_email }}>
+          author: {{release_user}} <{{ release_email }}>
           branch: minor-version-bump
           base: {{ plugin_default_branch }}
           title: Bump minor version

--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -40,10 +40,10 @@ jobs:
           pip install bandersnatch bump2version gitpython python-redmine towncrier==19.9.0 wheel
           echo ::endgroup::
 
-      - name: Configure Git with pulpbot name and email
+      - name: Configure Git with {{ release_user }} name and email
         run: |
-          git config --global user.name 'pulpbot'
-          git config --global user.email 'pulp-infra@redhat.com'
+          git config --global user.name '{{ release_user }}'
+          git config --global user.email '{{ release_email }}'
 
       - name: Setting secrets
         run: python3 .github/workflows/scripts/secrets.py "$SECRETS_CONTEXT"
@@ -217,10 +217,10 @@ jobs:
         with:
           ruby-version: "2.6"
 
-      - name: Configure Git with pulpbot name and email
+      - name: Configure Git with {{ release_user }} name and email
         run: |
-          git config --global user.name 'pulpbot'
-          git config --global user.email 'pulp-infra@redhat.com'
+          git config --global user.name '{{ release_user }}'
+          git config --global user.email '{{ release_email }}'
 
       - name: Untar repository
         run: |
@@ -310,8 +310,8 @@ jobs:
       - name: Create Pull Request for Changelog
         uses: peter-evans/create-pull-request@v3
         with:
-          committer: {{  'pulpbot <pulp-infra@redhat.com>' }}
-          author: {{  'pulpbot <pulp-infra@redhat.com>' }}
+          committer: {{release_user}} <{{ release_email }}>
+          author: {{release_user}} <{{ release_email }}>
           branch: changelog/{{ "${{ github.event.inputs.release }}" }}
           base: {{ plugin_default_branch }}
           title: 'Building changelog for {{ "${{ github.event.inputs.release }}" }}'

--- a/templates/github/.github/workflows/update_ci.yml.j2
+++ b/templates/github/.github/workflows/update_ci.yml.j2
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Configure Git with pulpbot name and email
+      - name: Configure Git with {{ release_user }} name and email
         run: |
-          git config --global user.name 'pulpbot'
-          git config --global user.email 'pulp-infra@redhat.com'
+          git config --global user.name '{{ release_user }}'
+          git config --global user.email '{{ release_email }}'
 
       - name: Run update
         run: |
@@ -33,12 +33,12 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           token: {{ '${{ secrets.RELEASE_TOKEN }}' }}
-          committer: {{  'pulpbot <pulp-infra@redhat.com>' }}
-          author: {{  'pulpbot <pulp-infra@redhat.com>' }}
+          committer: {{release_user}} <{{ release_email }}>
+          author: {{release_user}} <{{ release_email }}>
           title: 'Update CI files'
-          body: '[noissue]'
+          body: '{{ noissue_marker | default("[noissue]") }}'
           commit-message: |
             Update CI files
 
-            [noissue]
+            {{ noissue_marker | default("[noissue]") }}
           delete-branch: true


### PR DESCRIPTION
Galaxy uses `No-Issue` to mark commits not attached to issues