### PR TITLE
Add ability to add extra envvars and specify git revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The following settings are stored in `template_config.yml`.
                         name: the name of the plugin
                         bindings (optional): boolean whether or not generate bindings
                         org (optional): github organization
+                        revision (optional): the git commit hash to install.
+                                             "Required PR" in a commit message will override this. 
                         branch: the git branch of the plugin. applies to non-tagged GHA jobs, such as PRs & cron jobs.
                         pip_version_specifier: A pip version specifier for when the gets installed from PyPI.
                                                Applies to TAGGED (release) jobs.
@@ -171,6 +173,8 @@ The following settings are stored in `template_config.yml`.
 
   pulp_settings         A dictionary of settings that the plugin tests require to be set.
 
+  pulpcore_revision     The git commit hash to check out and install in Github Actions.
+                        "Required PR" in a commit message will override this.
   pulpcore_branch       The branch of pulpcore to check out and install in Github Actions.
                         This only applies to non-tagged jobs, such as PRs & cron jobs.
                         "Required PR" in a commit message will override this.
@@ -232,7 +236,7 @@ The following settings are stored in `template_config.yml`.
                         or merged, and when the changes are released.
 
   ci_trigger            Value for the `on` clause on workflow/ci.yml (push, pull_request, etc...)
-
+  ci_env                Environment variables to set for the CI build.
   pre_job_template      holds name and a path for a template to be included to run before jobs.
   post_job_template     holds name and a path for a template to be included to run after jobs.
 ```

--- a/plugin-template
+++ b/plugin-template
@@ -50,6 +50,7 @@ DEFAULT_SETTINGS = {
     "publish_docs_to_pulpprojectdotorg": False,
     "pulp_settings": None,
     "pulpcore_branch": "master",
+    "pulpcore_revision": None,
     "pulpcore_pip_version_specifier": None,
     "pulpprojectdotorg_key_id": None,
     "pydocstyle": True,
@@ -67,6 +68,7 @@ DEFAULT_SETTINGS = {
     "test_s3": False,
     "update_redmine": False,
     "ci_trigger": "{pull_request: {branches: ['*']}}",
+    "ci_env": {},
     "pre_job_template": None,
     "post_job_template": None,
 }

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -31,6 +31,9 @@ jobs:
         env:
           GITHUB_TOKEN: {{ "${{ secrets.GITHUB_TOKEN }}" }}
           GITHUB_CONTEXT: {{ "${{ github.event.pull_request.commits_url }}" }}
+          {%- for key, value in ci_env.items() %} 
+          {{ key }}: {{ value }}
+          {%- endfor %}
         run: sh .github/workflows/scripts/check_commit.sh
       {%- endif %}
 
@@ -118,6 +121,9 @@ jobs:
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
+          {%- for key, value in ci_env.items() %} 
+          {{ key }}: {{ value }}
+          {%- endfor %}
         shell: bash
 
       - name: Install Python client
@@ -145,6 +151,9 @@ jobs:
           GITHUB_PULL_REQUEST: {{ "${{ github.event.number }}" }}
           GITHUB_BRANCH: {{ "${{ github.head_ref }}" }}
           GITHUB_REPO_SLUG: {{ "${{ github.repository }}" }}
+          {%- for key, value in ci_env.items() %} 
+          {{ key }}: {{ value }}
+          {%- endfor %}
 
       - name: After failure
         if: failure()
@@ -219,6 +228,9 @@ jobs:
         env:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
+          {%- for key, value in ci_env.items() %} 
+          {{ key }}: {{ value }}
+          {%- endfor %}
         shell: bash
 
       - name: Install Python client

--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -119,6 +119,7 @@ cd ..
 git clone --depth=1 https://github.com/pulp/pulpcore.git --branch {{ pulpcore_branch }}
 
 cd pulpcore
+{% if pulpcore_revision %}git checkout {{ pulpcore_revision }}{% endif %}
 if [ -n "$PULPCORE_PR_NUMBER" ]; then
   git fetch --depth=1 origin pull/$PULPCORE_PR_NUMBER/head:$PULPCORE_PR_NUMBER
   git checkout $PULPCORE_PR_NUMBER
@@ -129,12 +130,14 @@ cd ..
 {%- for plugin in additional_repos %}
 
 git clone --depth=1 https://github.com/{{plugin.org | default("pulp")}}/{{ plugin.name }}.git --branch {{ plugin.branch }}
+cd {{ plugin.name }}
+{% if plugin.revision %}git checkout {{ plugin.revision }}{% endif %}
 if [ -n "${{ plugin.name | upper | replace("-", "_") }}_PR_NUMBER" ]; then
-  cd {{ plugin.name }}
   git fetch --depth=1 origin pull/${{ plugin.name | upper | replace("-", "_") }}_PR_NUMBER/head:${{ plugin.name | upper | replace("-", "_") }}_PR_NUMBER
   git checkout ${{ plugin.name | upper | replace("-", "_") }}_PR_NUMBER
-  cd ..
 fi
+
+cd ..
 {%- endfor %}
 
 {% if upgrade_range %}

--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -31,7 +31,7 @@ TAG=ci_build
 if [ -e $REPO_ROOT/../{{ item.name }} ]; then
   {{ item.name | upper | replace("-", "_") }}=./{{ item.name }}
 else
-  {{ item.name | upper | replace("-", "_") }}=git+https://github.com/{{item.org | default("pulp")}}/{{ item.name }}.git@{{ item.branch }}
+  {{ item.name | upper | replace("-", "_") }}=git+https://github.com/{{item.org | default("pulp")}}/{{ item.name }}.git@{{ item.revision | default(item.branch) }}
 fi
 {%- endfor %}
 


### PR DESCRIPTION
This introduces 2 features:

- ci_env: {}
  Extra CI env vars can be specified to be added to `env` on install and
script jobs.
- revision/pulpcore_revision
  Optional git revision to be checked out on the cloned repo.

Ref: https://github.com/ansible/galaxy_ng/pull/897

[noissue]