### PR TITLE
Fix update ci script

### DIFF
--- a/templates/github/.github/workflows/scripts/update_ci.sh.j2
+++ b/templates/github/.github/workflows/scripts/update_ci.sh.j2
@@ -19,7 +19,7 @@ popd
 
 if [[ `git status --porcelain` ]]; then
   git add -A
-  git commit -m "Update CI files" -m "[noissue]"
+  git commit -m "Update CI files" -m "{{ noissue_marker | default('[noissue]') }}"
 else
   echo "No updates needed"
 fi


### PR DESCRIPTION
runs on galaxy_ng was failing because PR was opened using [noissue] instead of No-Issue

example: https://github.com/ansible/galaxy_ng/pull/910/commits