### PR TITLE
Skip Update CI PR if only template_gitref has changed.

### DIFF
--- a/templates/github/.github/workflows/scripts/update_ci.sh.j2
+++ b/templates/github/.github/workflows/scripts/update_ci.sh.j2
@@ -17,6 +17,13 @@ pushd ../plugin_template
 ./plugin-template --github {{ plugin_name }}
 popd
 
+# Check if only gitref file has changed, so no effect on CI workflows.
+if [[ `git diff --name-only` == ".github/template_gitref" ]]; then
+  echo "CI update has no effect on workflows, skipping PR creation."
+  git stash
+  exit 0
+fi
+
 if [[ `git status --porcelain` ]]; then
   git add -A
   git commit -m "Update CI files" -m "{{ noissue_marker | default('[noissue]') }}"


### PR DESCRIPTION
When template update has no effect on workflows there is a
change on template_gitref and then useless PRs are opened.

[noissue]