### PR TITLE
Add tasking_allow_async_unsafe flag

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -72,6 +72,7 @@ DEFAULT_SETTINGS = {
     "ci_env": {},
     "pre_job_template": None,
     "post_job_template": None,
+    "tasking_allow_async_unsafe": True,
 }
 
 

--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -168,6 +168,11 @@ fi
 
 sed -i -e 's/DEBUG = False/DEBUG = True/' pulpcore/pulpcore/app/settings.py
 
+{% if not tasking_allow_async_unsafe -%}
+# Patch DJANGO_ALLOW_ASYNC_UNSAFE out of the pulpcore tasking_system
+# Don't let it fail. Be opportunistic.
+sed -i -e '/DJANGO_ALLOW_ASYNC_UNSAFE/d' ../pulpcore/pulpcore/tasking/entrypoint.py || true
+{% endif -%}
 cd {{ plugin_name }}
 
 if [ -f $POST_BEFORE_INSTALL ]; then


### PR DESCRIPTION
Plugins that reviewed their tasks to be async safe should disable this.

[noissue]