### PR TITLE
Set an upper bound for mistune

### DIFF
--- a/templates/docs/doc_requirements.txt.j2
+++ b/templates/docs/doc_requirements.txt.j2
@@ -9,3 +9,4 @@ sphinx<1.8.0
 sphinx-rtd-theme
 sphinxcontrib-openapi
 towncrier
+mistune<2.0.0


### PR DESCRIPTION
This temporary change is required to resolve issues in the CI pipeline (docs runner).

The change is inspired by https://github.com/miyakogi/m2r/issues/66.

[noissue]