### PR TITLE
Add plugin template parallel running supports

### DIFF
--- a/CHANGES/546.feature
+++ b/CHANGES/546.feature
@@ -1,0 +1,4 @@
+Added the ``parallel_test_workers`` template_config.yml variable which defaults to 8. This variable
+specifies the number of processes to run tests in parallel with. Tests can be marked as runnable in
+parallel with the ``@pytest.mark.parallel`` decorator. Setting this variable to 0 disables parallel
+running entirely.

--- a/README.md
+++ b/README.md
@@ -144,10 +144,15 @@ The following settings are stored in `template_config.yml`.
   aiohttp_fixtures_origin
                         Identifies the network origin of the aiohttp fixtures.
 
-  issue_tracker         Which issue tracker the project will use. Valid values are 'redmine' and 'github'.
-                        To switch from Redmine to GitHub use the --migrate-github-issues option.
+  issue_tracker         Which issue tracker the project will use. Valid values are 'redmine' and
+                        'github'. To switch from Redmine to GitHub use the --migrate-github-issues
+                        option.
 
   docs_test             Include a CI build for testing the 'make html' command for sphinx docs.
+
+  parallel_test_workers Run tests in parallel using `pytest-xdist` with N parallel runners. This
+                        settings specifies N. By default it is 8. Setting to 0 will disable parallel
+                        test running.
 
   plugin_app_label      Suppose our plugin is named 'pulp_test', then this is 'test'
 

--- a/plugin-template
+++ b/plugin-template
@@ -37,6 +37,7 @@ DEFAULT_SETTINGS = {
     "docker_fixtures": False,
     "docs_test": True,
     "issue_tracker": "github",
+    "parallel_test_workers": 8,
     "pulp_scheme": "https",
     "plugin_app_label": None,
     "plugin_camel": None,

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -186,7 +186,12 @@ fi
 if [ -f $FUNC_TEST_SCRIPT ]; then
   source $FUNC_TEST_SCRIPT
 else
+{% if parallel_test_workers == 0 %}
     pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional
+{% else %}
+    pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin_snake }}.tests.functional -m parallel -n {{ parallel_test_workers }}
+    pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional -m "not parallel"
+{% endif %}
 fi
 
 {%- if test_cli %}


### PR DESCRIPTION
Adds the `parallel_test_workers` which defaults to 8. This runs any test 
marked with `@pytest.mark.parallel` to run in parallel with N concurrent
processes. Setting this value to 0 disables parallel running altogether.

closes #546