### PR TITLE
Check upper bound for our requirements.txt deps

### DIFF
--- a/CHANGES/614.feature
+++ b/CHANGES/614.feature
@@ -1,0 +1,1 @@
+Check upper bound for our requirements.txt deps

--- a/templates/github/.ci/scripts/upper_bound.py.j2
+++ b/templates/github/.ci/scripts/upper_bound.py.j2
@@ -1,0 +1,12 @@
+from pkg_resources import Requirement
+
+packages = []
+with open("requirements.txt", "r") as fd:
+    for line in fd.readlines():
+        req = Requirement.parse(line)
+        if len(req.specs) < 2 and "~=" not in str(req.specs) and "==" not in str(req.specs):
+            packages.append(req.name)
+if packages:
+    raise RuntimeError(
+        "The following packages are missing upper bound: {}".format(", ".join(packages))
+    )

--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -47,6 +47,9 @@ jobs:
 
       {{ set_secrets() | indent(6) }}
 
+      - name: Verify upper bound requirements
+        run: python .ci/scripts/upper_bound.py
+
       - name: Create the release commit, tag it, create a post-release commit, and build plugin package
         run: python .github/workflows/scripts/release.py {{ "${{ github.event.inputs.release }}" }}
 


### PR DESCRIPTION
```python
pulpcore on  main [$] via 🐍 v3.10.0 (venv) took 24m31s 
❯ ipython
Python 3.10.0 (default, Dec  2 2021, 14:45:52) [GCC 11.2.1 20210728 (Red Hat 11.2.1-1)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from pkg_resources import Requirement
   ...: 
   ...: packages = []
   ...: with open("requirements.txt", "r") as fd:
   ...:     for line in fd.readlines():
   ...:         req = Requirement.parse(line)
   ...:         if len(req.specs) < 2 and "~=" not in str(req.specs) and "==" not in str(req.specs):
   ...:             packages.append(req.name)
   ...: if packages:
   ...:     raise RuntimeError("The following packages are missing upper bound: {}".format(", ".join(packages)))
   ...: 
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-1-4efaaf3e0e8b> in <module>
     10             packages.append(req.name)
     11 if packages:
---> 12     raise RuntimeError("The following packages are missing upper bound: {}".format(", ".join(packages)))

RuntimeError: The following packages are missing upper bound: click, jinja2, redis, setuptools, yarl
```