### PR TITLE
pulpcore is now a pytest plugin

### DIFF
--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -19,6 +19,7 @@ if [[ "$TEST" = "docs" || "$TEST" = "publish" ]]; then
   pip install -r doc_requirements.txt
 fi
 
+pip install -e ../pulpcore
 pip install -r functest_requirements.txt
 
 cd .ci/ansible/

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -113,16 +113,13 @@ cmd_prefix bash -c "django-admin makemigrations --check --dry-run"
 
 if [[ "$TEST" != "upgrade" ]]; then
   # Run unit tests.
-  cmd_prefix bash -c "PULP_DATABASES__default__USER=postgres pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.unit"
+  cmd_prefix bash -c "PULP_DATABASES__default__USER=postgres pytest -v -r sx --color=yes -p no:pulpcore --pyargs {{ plugin_snake }}.tests.unit"
 fi
 
 # Run functional tests
 {%- for repo in additional_repos %}
 export PYTHONPATH=$REPO_ROOT/../{{repo.name}}${PYTHONPATH:+:${PYTHONPATH}}
 {%- endfor %}
-{%- if not plugin_name == 'pulpcore' %}
-export PYTHONPATH=$REPO_ROOT/../pulpcore${PYTHONPATH:+:${PYTHONPATH}}
-{%- endif %}
 export PYTHONPATH=$REPO_ROOT${PYTHONPATH:+:${PYTHONPATH}}
 
 {% if upgrade_range %}
@@ -154,6 +151,13 @@ if [[ "$TEST" == "upgrade" ]]; then
 
   echo "Restarting in 60 seconds"
   sleep 60
+
+  # Let's reinstall pulpcore so we can ensure we have the correct dependencies
+  cd ../pulpcore
+  git checkout -f ci_upgrade_test
+  pip install --upgrade --force-reinstall .
+  cd ..
+  pip install --upgrade ../pulp-cli ../pulp-smash
 
   # CLI commands to display plugin versions and content data
   pulp status


### PR DESCRIPTION
To have pulpcore provide its pytest fixtures via a pytest plugin we need
to do two things:

1) We can't have the unittests (which run inside the container) evaluate
   the pulpcore plugin because they expect pulp_smash to be configured
   and inside the container pulp smash isn't configured. The unittests
   don't need the pulpcore fixtures though so just ignoring it with the
   `-p no:pulpcore` is all that's needed.

2) Have pulpcore actually installed outside of the container so that the
   functional tests can discover them. A pytest plugin needs to be
   "normally installed" and can't be done through pythonpath
   manipulation.

Also due to (2) we no longer need to manipulate `PYTHONPATH` for
pulpcore anymore, so that has been removed.

[noissue]