### PR TITLE
Use `--nightly` flag now provided by pulp-smash

### DIFF
--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -124,6 +124,16 @@ if [ -f $FUNC_TEST_SCRIPT ]; then
 else
 {% if parallel_test_workers == 0 %}
     if [[ "$GITHUB_WORKFLOW" == "{{ plugin_camel_short | default("Pulp") }} Nightly CI/CD" ]]; then
+        pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional  --nightly
+
+    {%- for item in additional_repos if item.pytest_args | default(false) %}
+        pytest -v -r sx --color=yes --pyargs {{ item.pytest_args }} --nightly
+    {%- endfor %}
+
+    {% if run_pulpcore_tests_for_plugins %}
+        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins" --nightly
+    {% endif %}
+    else
         pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional
 
     {%- for item in additional_repos if item.pytest_args | default(false) %}
@@ -133,19 +143,22 @@ else
     {% if run_pulpcore_tests_for_plugins %}
         pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins"
     {% endif %}
-    else
-        pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional -m "not nightly"
-
-    {%- for item in additional_repos if item.pytest_args | default(false) %}
-        pytest -v -r sx --color=yes --pyargs {{ item.pytest_args }} -m "not nightly"
-    {%- endfor %}
-
-    {% if run_pulpcore_tests_for_plugins %}
-        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins and not nightly"
-    {% endif %}
     fi
 {% else %}
     if [[ "$GITHUB_WORKFLOW" == "{{ plugin_camel_short | default("Pulp") }} Nightly CI/CD" ]]; then
+        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin_snake }}.tests.functional -m parallel -n {{ parallel_test_workers }}  --nightly
+        pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional -m "not parallel"  --nightly
+
+    {%- for item in additional_repos if item.pytest_args | default(false) %}
+        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ item.pytest_args }} -m parallel -n {{ parallel_test_workers }}  --nightly
+        pytest -v -r sx --color=yes --pyargs {{ item.pytest_args }} -m "not parallel"  --nightly
+    {%- endfor %}
+
+    {% if run_pulpcore_tests_for_plugins %}
+        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins and parallel" -n  {{ parallel_test_workers }}  --nightly
+        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins and not parallel"  --nightly
+    {% endif %}
+    else
         pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin_snake }}.tests.functional -m parallel -n {{ parallel_test_workers }}
         pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional -m "not parallel"
 
@@ -157,19 +170,6 @@ else
     {% if run_pulpcore_tests_for_plugins %}
         pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins and parallel" -n  {{ parallel_test_workers }}
         pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins and not parallel"
-    {% endif %}
-    else
-        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin_snake }}.tests.functional -m "parallel and not nightly" -n {{ parallel_test_workers }}
-        pytest -v -r sx --color=yes --pyargs {{ plugin_snake }}.tests.functional -m "not parallel and not nightly"
-
-    {%- for item in additional_repos if item.pytest_args | default(false) %}
-        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ item.pytest_args }} -m "parallel and not nightly" -n {{ parallel_test_workers }}
-        pytest -v -r sx --color=yes --pyargs {{ item.pytest_args }} -m "not parallel and not nightly"
-    {%- endfor %}
-
-    {% if run_pulpcore_tests_for_plugins %}
-        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins and not nightly and parallel" -n  {{ parallel_test_workers }}
-        pytest -v -r sx --color=yes --suppress-no-test-exit-code --pyargs pulpcore.tests.functional -m "from_pulpcore_for_all_plugins and not nightly and not parallel"
     {% endif %}
     fi
 {% endif %}


### PR DESCRIPTION
Now pulp-smash disincludes tests marked as nightly by default, and to
run the entire set (including nightly) you use the `--nightly` flag.
This adjusts the test runners to select and run the right tests
depending on if its a nightly run or not.

[noissue]