### PR TITLE
Revert "Install additional plugins to provide pytest parts"

### DIFF
--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -21,7 +21,7 @@ if [[ "$TEST" = "docs" || "$TEST" = "publish" ]]; then
   pip install -r doc_requirements.txt
 fi
 
-pip install -e ../pulpcore {%- for item in additional_repos %} -e ../{{ item.name }} {%- endfor %}
+pip install -e ../pulpcore
 pip install -r functest_requirements.txt
 
 cd .ci/ansible/


### PR DESCRIPTION
Reverts pulp/plugin_template#643

it breaks when pulp-rpm is listed on additional plugins, as pulp-rpm can't be installed on ubuntu
https://github.com/pulp/pulp-2to3-migration/runs/6749755516?check_suite_focus=true
https://github.com/pulp/pulp-2to3-migration/blob/main/template_config.yml#L12