### PR TITLE
Remove `test_bindings` feature

### DIFF
--- a/.ci/bootstrap_catdog.sh
+++ b/.ci/bootstrap_catdog.sh
@@ -14,12 +14,9 @@ echo $COMMIT_MSG
 pip install -r test_requirements.txt
 ./plugin-template --generate-config --plugin-app-label catdog pulp_catdog
 mkdir -p ../pulp_catdog/.ci/assets/bindings
-touch ../pulp_catdog/.ci/assets/bindings/test_bindings.py
-touch ../pulp_catdog/.ci/assets/bindings/test_bindings.rb
 echo 'pypi_username: the_pypi_user' >> ../pulp_catdog/template_config.yml
 sed -i "s/test_s3: false/test_s3: true/g" ../pulp_catdog/template_config.yml
 sed -i "s/test_azure: false/test_azure: true/g" ../pulp_catdog/template_config.yml
-sed -i "s/test_bindings: true/test_bindings: false/g" ../pulp_catdog/template_config.yml
 sed -i "s/disabled_redis_runners: \[\]/disabled_redis_runners: [s3]/g" ../pulp_catdog/template_config.yml
 ./plugin-template --all pulp_catdog
 

--- a/README.md
+++ b/README.md
@@ -232,13 +232,6 @@ The following settings are stored in `template_config.yml`.
 
   sync_ci               Enables a nightly workflow to update the CI files.
 
-  test_bindings         Include a job that runs a script to test generated client
-                        library.
-
-                        This job requires the plugin author to include a 'test_bindings.rb'
-                        script in the ./.ci/assets/bindings directory of the plugin repository. This
-                        script is supposed to exercise the generated client library.
-
   test_cli              Run the pulp-cli tests as part of the CI tests
 
   test_performance      Include a nightly job that runs a script to test performance. If using a

--- a/plugin-template
+++ b/plugin-template
@@ -68,7 +68,6 @@ DEFAULT_SETTINGS = {
     "stalebot_days_until_close": 30,
     "stalebot_limit_to_pulls": True,
     "sync_ci": True,
-    "test_bindings": True,
     "test_cli": False,
     "test_deprecations": True,
     "test_performance": False,

--- a/templates/bootstrap/plugin_name/app/__init__.py.j2
+++ b/templates/bootstrap/plugin_name/app/__init__.py.j2
@@ -7,3 +7,4 @@ class {{ plugin_camel }}PluginAppConfig(PulpPluginAppConfig):
     name = "{{ plugin_snake }}.app"
     label = "{{ plugin_app_label }}"
     version = "0.1.0a1.dev"
+    python_package_name = "{{ plugin_name }}"

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -111,9 +111,6 @@ jobs:
           {%- if test_stream %}
           - TEST: stream
           {%- endif %}
-          {%- if test_bindings %}
-          - TEST: bindings
-          {%- endif %}
     outputs:
       deprecations-pulp: {{ "${{ steps.deprecations.outputs.deprecations-pulp }}" }}
       {%- if test_stream %}
@@ -125,18 +122,11 @@ jobs:
       {%- if test_s3 %}
       deprecations-s3: {{ "${{ steps.deprecations.outputs.deprecations-s3 }}" }}
       {%- endif %}
-      {%- if test_bindings %}
-      deprecations-bindings: {{ "${{ steps.deprecations.outputs.deprecations-bindings }}" }}
-      {%- endif %}
 
     steps:
       {{ checkout() | indent(6) }}
 
       {{ setup_python() | indent(6) }}
-
-      {%- if test_bindings %}
-      {{ setup_ruby() | indent(6) }}
-      {%- endif %}
 
       {{ install_httpie() | indent(6) }}
 
@@ -180,9 +170,6 @@ jobs:
           {%- if test_s3 %}
           test -z "{{ "${{ needs.test.outputs.deprecations-s3 }}" }}"
           {%- endif %}
-          {%- if test_bindings %}
-          test -z "{{ "${{ needs.test.outputs.deprecations-bindings }}" }}"
-          {%- endif %}
       - name: Print deprecations
         if: failure()
         run: |
@@ -195,9 +182,6 @@ jobs:
           {%- endif %}
           {%- if test_s3 %}
           echo "{{ "${{ needs.test.outputs.deprecations-s3 }}" }}" | base64 -d
-          {%- endif %}
-          {%- if test_bindings %}
-          echo "{{ "${{ needs.test.outputs.deprecations-bindings }}" }}" | base64 -d
           {%- endif %}
 {%- endif %}
 

--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -42,10 +42,8 @@ jobs:
           {%- if test_stream %}
           - TEST: stream
           {%- endif %}
-          {%- if (deploy_daily_client_to_pypi or deploy_daily_client_to_rubygems) and not test_bindings %}
+          {%- if (deploy_daily_client_to_pypi or deploy_daily_client_to_rubygems) %}
           - TEST: generate-bindings
-          {%- elif test_bindings  %}
-          - TEST: bindings
           {%- endif %}
           {%- if test_released_plugin_with_next_pulpcore_release %}
           - TEST: plugin-from-pypi

--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -83,10 +83,8 @@ jobs:
           {%- if test_stream %}
           - TEST: stream
           {%- endif %}
-          {%- if (deploy_client_to_pypi or deploy_client_to_rubygems) and not test_bindings %}
+          {%- if (deploy_client_to_pypi or deploy_client_to_rubygems) %}
           - TEST: generate-bindings
-          {%- elif test_bindings  %}
-          - TEST: bindings
           {%- endif %}
 
     steps:
@@ -96,7 +94,7 @@ jobs:
 
       {{ setup_python() | indent(6) }}
 
-      {%- if test_bindings or deploy_client_to_rubygems %}
+      {%- if deploy_client_to_rubygems %}
       {{ setup_ruby() | indent(6) }}
       {%- endif %}
 

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -82,16 +82,6 @@ fi
 {%- endfor %}
 cd $REPO_ROOT
 
-if [[ "$TEST" = 'bindings' ]]; then
-  if [ -f $REPO_ROOT/.ci/assets/bindings/test_bindings.py ]; then
-    python $REPO_ROOT/.ci/assets/bindings/test_bindings.py
-  fi
-  if [ -f $REPO_ROOT/.ci/assets/bindings/test_bindings.rb ]; then
-    ruby $REPO_ROOT/.ci/assets/bindings/test_bindings.rb
-  fi
-  exit
-fi
-
 cat unittest_requirements.txt | cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt"
 cmd_prefix pip3 install -r /tmp/unittest_requirements.txt
 


### PR DESCRIPTION
This test runner is only used in one place, and is such limimted value
that we should not maintain this test runner.

Discussion occured here some on this change: https://discourse.pulpproject.org/t/ci-cd-removing-unecessary-bindings-runner/474/

[noissue]