### PR TITLE
[bugfix] Make lint_requirements optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The following settings are stored in `template_config.yml`.
   ci_env                Environment variables to set for the CI build.
   pre_job_template      holds name and a path for a template to be included to run before jobs.
   post_job_template     holds name and a path for a template to be included to run after jobs.
+  lint_requirements     Boolean (defaults True) to enable upper bound check on requirements.txt
 ```
 
 # Bootstrap a new Pulp plugin

--- a/plugin-template
+++ b/plugin-template
@@ -83,6 +83,7 @@ DEFAULT_SETTINGS = {
     "pre_job_template": None,
     "post_job_template": None,
     "tasking_allow_async_unsafe": True,
+    "lint_requirements": True,
 }
 
 

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -89,8 +89,10 @@ jobs:
         run: sh .ci/scripts/check_gettext.sh
       {%- endif %}
 
+      {% if lint_requirements -%}
       - name: Verify upper bound requirements
         run: python .ci/scripts/upper_bound.py
+      {%- endif %}
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reason: By default this check `upper_bounds.py` looks for a `requirements.txt`
and galaxy_ng doesn´t have that file and it was failing teh CI.

[noissue]