### PR TITLE
Disable upper_bound check for plugins with no requirements.txt

### DIFF
--- a/templates/github/.ci/scripts/upper_bound.py.j2
+++ b/templates/github/.ci/scripts/upper_bound.py.j2
@@ -2,16 +2,22 @@ import warnings
 from pkg_resources import Requirement
 
 packages = []
-with open("requirements.txt", "r") as fd:
-    for line in fd.readlines():
-        if not line.startswith("#"):
-            req = Requirement.parse(line)
-            spec = str(req.specs)
-            if "~=" in spec:
-                warnings.warn(f"Please avoid using ~= on {req.name}")
-                continue
-            if len(req.specs) < 2 and "==" not in spec and "<" not in spec:
-                packages.append(req.name)
+
+try:
+    with open("requirements.txt", "r") as fd:
+        for line in fd.readlines():
+            if not line.startswith("#"):
+                req = Requirement.parse(line)
+                spec = str(req.specs)
+                if "~=" in spec:
+                    warnings.warn(f"Please avoid using ~= on {req.name}")
+                    continue
+                if len(req.specs) < 2 and "==" not in spec and "<" not in spec:
+                    packages.append(req.name)
+except FileNotFoundError:
+    # skip this test for plugins that don't use a requirements.txt
+    pass
+
 if packages:
     raise RuntimeError(
         "The following packages are missing upper bound: {}".format(", ".join(packages))


### PR DESCRIPTION
Galaxy NG defines requirements in setup.py, so this test currently fails because no reuqirements file is available.