### PR TITLE
Install pulp-cli not in editable mode

### DIFF
--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -98,7 +98,7 @@ if [ -n "$PULP_CLI_PR_NUMBER" ]; then
 fi
 
 cd pulp-cli
-pip install -e .
+pip install .
 pulp config create --base-url {{ pulp_scheme }}://pulp --location tests/cli.toml {% if pulp_scheme != 'https' %}--no-verify-ssl{% endif %}
 mkdir ~/.config/pulp
 cp tests/cli.toml ~/.config/pulp/cli.toml


### PR DESCRIPTION
For some reason on GHA pulp-cli installed in editable mode is causing python to not be
able to import `pulpcore.cli`.

[noissue]