### PR TITLE
Disable telemetry in the CI

### DIFF
--- a/templates/github/.ci/ansible/settings.py.j2.copy
+++ b/templates/github/.ci/ansible/settings.py.j2.copy
@@ -8,6 +8,7 @@ TOKEN_SIGNATURE_ALGORITHM = "ES256"
 CACHE_ENABLED = True
 REDIS_HOST = "localhost"
 REDIS_PORT = 6379
+TELEMETRY = False
 
 {% if api_root is defined %}
 API_ROOT = {{ api_root | repr }}


### PR DESCRIPTION
Telemetry should be run only on end-user sytems. It's likely creating false positives when the CI template leaves telemetry enabled.

The CI for telemetry will come in the form of unit tests for pulpcore, so running it here isn't even helpful.

[noissue]