### PR TITLE
Remove allow_async_unsafe

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -87,7 +87,6 @@ DEFAULT_SETTINGS = {
     "ci_env": {},
     "pre_job_template": None,
     "post_job_template": None,
-    "tasking_allow_async_unsafe": True,
     "lint_requirements": True,
 }
 

--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -146,12 +146,6 @@ then
   exit $s
 fi
 
-{%- if not tasking_allow_async_unsafe %}
-# Patch DJANGO_ALLOW_ASYNC_UNSAFE out of the pulpcore tasking_system
-# Don't let it fail. Be opportunistic.
-sed -i -e '/DJANGO_ALLOW_ASYNC_UNSAFE/d' pulpcore/pulpcore/tasking/entrypoint.py || true
-{%- endif %}
-
 cd {{ plugin_name }}
 
 if [ -f $POST_BEFORE_INSTALL ]; then


### PR DESCRIPTION
This requires that we stop updating the CI on the 3.14 branch, which I think is actually perfectly fine at this point.