### PR TITLE
Use 4 pulp worker processes in the container

### DIFF
--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -119,6 +119,8 @@ services:
       - ./ssh:/keys/
       - ~/.config:/root/.config
       - ../../../pulp-openapi-generator:/root/pulp-openapi-generator
+    env:
+      PULP_WORKERS: "4"
 VARSYAML
 
 cat >> vars/main.yaml << VARSYAML


### PR DESCRIPTION
rather than the default of 2.

This is because the github actions CI only has 2 cores, even though
parallel_test_workers defaults to 8 and is configurable.

[noissue]