### PR TITLE
Revert cmd_prefix and similar from aliases to functions

### DIFF
--- a/templates/github/.github/workflows/scripts/before_script.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_script.sh.j2
@@ -7,7 +7,6 @@ cd "$(dirname "$(realpath -e "$0")")"/../../..
 
 set -euv
 
-shopt -s expand_aliases
 source .github/workflows/scripts/utils.sh
 
 export PRE_BEFORE_SCRIPT=$PWD/.github/workflows/scripts/pre_before_script.sh

--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -8,7 +8,6 @@ REPO_ROOT="$PWD"
 
 set -euv
 
-shopt -s expand_aliases
 source .github/workflows/scripts/utils.sh
 
 export PULP_API_ROOT="{{ api_root }}"

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -9,7 +9,6 @@ REPO_ROOT="$PWD"
 
 set -mveuo pipefail
 
-shopt -s expand_aliases
 source .github/workflows/scripts/utils.sh
 
 export POST_SCRIPT=$PWD/.github/workflows/scripts/post_script.sh

--- a/templates/github/.github/workflows/scripts/utils.sh.j2
+++ b/templates/github/.github/workflows/scripts/utils.sh.j2
@@ -2,14 +2,24 @@
 
 {% include 'header.j2' %}
 
+PULP_CI_CONTAINER=pulp
+
 # Run a command
-alias cmd_prefix='docker exec pulp'
+cmd_prefix() {
+  docker exec "$PULP_CI_CONTAINER" "$@"
+}
 
 # Run a command as the limited pulp user
-alias cmd_user_prefix='docker exec -u pulp pulp'
+cmd_user_prefix() {
+  docker exec -u pulp "$PULP_CI_CONTAINER" "$@"
+}
 
 # Run a command, and pass STDIN
-alias cmd_stdin_prefix='docker exec -i pulp'
+cmd_stdin_prefix() {
+  docker exec -i "$PULP_CI_CONTAINER" "$@"
+}
 
 # Run a command as the lmited pulp user, and pass STDIN
-alias cmd_user_stdin_prefix='docker exec -i -u pulp pulp'
+cmd_user_stdin_prefix() {
+  docker exec -i -u pulp "$PULP_CI_CONTAINER" "$@"
+}


### PR DESCRIPTION
Allevitates needs for scripts like post_script.sh to allow aliases.
(`shopt -s expand_aliases`)


[noissue]