### PR TITLE
Fix ~pulp/.netrc not being crated with the correct

### DIFF
--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -59,8 +59,8 @@ fi
 echo "machine pulp
 login admin
 password password
-" | cmd_stdin_prefix bash -c "cat > ~pulp/.netrc"
-cmd_stdin_prefix bash -c "chmod og-rw ~pulp/.netrc"
+" | cmd_user_stdin_prefix bash -c "cat >> ~pulp/.netrc"
+cmd_user_stdin_prefix bash -c "chmod og-rw ~pulp/.netrc"
 
 cat unittest_requirements.txt | cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt"
 cat functest_requirements.txt | cmd_stdin_prefix bash -c "cat > /tmp/functest_requirements.txt"


### PR DESCRIPTION
permissions.

Also, make it so that earlier scripts can write to it too.

[noissue]