### PR TITLE
Fix ~/.netrc not being created with the correct permissions

### DIFF
--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -217,6 +217,11 @@ ansible-playbook start_container.yaml
 chmod 777 ~/.config/pulp_smash/
 chmod 666 ~/.config/pulp_smash/settings.json
 sudo chown -R 700:700 ~runner/.config
+{% if test_cli -%}
+# Plugins often write to ~/.config/pulp/cli.toml from the host
+sudo chmod 777 ~runner/.config/pulp
+sudo chmod 666 ~runner/.config/pulp/cli.toml
+{%- endif %}
 
 {%- if pulp_scheme == "https" %}
 echo ::group::SSL

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -60,7 +60,8 @@ echo "machine pulp
 login admin
 password password
 " | cmd_user_stdin_prefix bash -c "cat >> ~pulp/.netrc"
-cmd_user_stdin_prefix bash -c "chmod og-rw ~pulp/.netrc"
+# Some commands like ansible-galaxy specifically require 600
+cmd_user_stdin_prefix bash -c "chmod 600 ~pulp/.netrc"
 
 cat unittest_requirements.txt | cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt"
 cat functest_requirements.txt | cmd_stdin_prefix bash -c "cat > /tmp/functest_requirements.txt"


### PR DESCRIPTION
(again).

Some apps like ansible-galaxy specifically require no group permissions.

Also fix permissions on ~/.config/pulp/cli.toml

[noissue]