### PR TITLE
Add ability to skip lowerbounds test

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ The following settings are stored in `template_config.yml`.
   test_gcp              Include gcp job for running tests using [fake-gcs-server](https://github.com/fsouza/fake-gcs-server)
                         to emulate GCP.
 
+  test_lowerbounds      Include lowerbounds job for running tests using lower bounds found in requirements.txt.
+
   test_s3               Include s3 job for running tests using [minio](https://github.com/minio/minio)
                         to emulate S3.
 

--- a/plugin-template
+++ b/plugin-template
@@ -75,6 +75,7 @@ DEFAULT_SETTINGS = {
     "sync_ci": True,
     "test_cli": False,
     "test_deprecations": True,
+    "test_lowerbounds": True,
     "test_performance": False,
     "test_released_plugin_with_next_pulpcore_release": False,
     "test_reroute": True,

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -118,7 +118,9 @@ jobs:
           {%- if test_stream %}
           - TEST: stream
           {%- endif %}
+          {%- if test_lowerbounds %}
           - TEST: lowerbounds
+          {%- endif %}
     outputs:
       deprecations-pulp: {{ "${{ steps.deprecations.outputs.deprecations-pulp }}" }}
       {%- if test_stream %}
@@ -130,7 +132,9 @@ jobs:
       {%- if test_s3 %}
       deprecations-s3: {{ "${{ steps.deprecations.outputs.deprecations-s3 }}" }}
       {%- endif %}
+      {%- if test_lowerbounds %}
       deprecations-lowerbounds: {{ "${{ steps.deprecations.outputs.deprecations-lowerbounds }}" }}
+      {%- endif %}
 
     steps:
       {{ checkout() | indent(6) }}
@@ -177,7 +181,9 @@ jobs:
           {%- if test_s3 %}
           test -z "{{ "${{ needs.test.outputs.deprecations-s3 }}" }}"
           {%- endif %}
+          {%- if test_lowerbounds %}
           test -z "{{ "${{ needs.test.outputs.deprecations-lowerbounds }}" }}"
+          {%- endif %}
       - name: Print deprecations
         if: failure()
         run: |
@@ -191,7 +197,9 @@ jobs:
           {%- if test_s3 %}
           echo "{{ "${{ needs.test.outputs.deprecations-s3 }}" }}" | base64 -d
           {%- endif %}
+          {%- if test_lowerbounds %}
           echo "{{ "${{ needs.test.outputs.deprecations-lowerbounds }}" }}" | base64 -d
+          {%- endif %}
 {%- endif %}
 
 {% if post_job_template -%}{{ "  " | indent }}{% include post_job_template.path %}{%- endif %}

--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -51,7 +51,9 @@ jobs:
           {%- if test_released_plugin_with_next_pulpcore_release %}
           - TEST: plugin-from-pypi
           {%- endif %}
+          {%- if test_lowerbounds %}
           - TEST: lowerbounds
+          {%- endif %}
 
     steps:
       {{ checkout() | indent(6) }}

--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -89,7 +89,9 @@ jobs:
           {%- if (deploy_client_to_pypi or deploy_client_to_rubygems) %}
           - TEST: generate-bindings
           {%- endif %}
+          {%- if test_lowerbounds %}
           - TEST: lowerbounds
+          {%- endif %}
 
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
Allow to skip the lowerbounds test, for example galaxy_ng does not have a single `requirements.txt` file.