### PR TITLE
Add concurrency statements to workflows

### DIFF
--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -13,6 +13,11 @@ with context %}
 ---
 name: {{ plugin_camel_short | default("Pulp") }} CI
 on: {{ ci_trigger | default("{pull_request: {branches: ['*']}}") }}
+
+concurrency:
+  group: {{ '${{ github.ref_name }}-${{ github.workflow }}' }}
+  cancel-in-progress: true
+
 jobs:
 {% if pre_job_template -%}{{ "  " | indent }}{% include pre_job_template.path %}{%- endif %}
 

--- a/templates/github/.github/workflows/codeql-analysis.yml.j2
+++ b/templates/github/.github/workflows/codeql-analysis.yml.j2
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '37 1 * * 6'
 
+concurrency:
+  group: {{ '${{ github.ref_name }}-${{ github.workflow }}' }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -21,6 +21,10 @@ on:
     - cron: '00 3 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: {{ '${{ github.ref_name }}-${{ github.workflow }}' }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
[noissue]

This will attempt to cancel any running CI job on a PR in case the branch of the PR got updated. This should free us up some valuable CI time on a hot day.