### PR TITLE
Fix check-release-script's Y release message

### DIFF
--- a/templates/github/.ci/scripts/check_release.py.j2
+++ b/templates/github/.ci/scripts/check_release.py.j2
@@ -94,9 +94,10 @@ def main():
                         ).split("=")[-1]
                         next_version = Version(next_version)
                         print(
-                            f"A new Y-release is needed!, New Version: {next_version.base_version}"
+                            f"A new Y-release is needed! New Version: {next_version.base_version}"
                         )
                         releases.append(next_version)
+                        break
 
         if len(releases) == 0:
             print("No new releases to perform.")


### PR DESCRIPTION
Just notice after running the script this week that I forgot to add this break statement to prevent printing the Y release message multiple times. 