### PR TITLE
Fix docs build for pulpcore during release

### DIFF
--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -138,6 +138,8 @@ jobs:
         run: |
           pip install towncrier==19.9.0
           towncrier --yes --version 4.0.0.ci
+          export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
+          export PULP_SETTINGS=$PWD/.ci/ansible/settings/settings.py
           make -C docs/ PULP_URL="{{ pulp_scheme }}://pulp" diagrams html
           tar -cvf docs/docs.tar docs/_build
 


### PR DESCRIPTION
These two env vars need to be set for pulpcore docs building outside of the pulp container, since pulpcore requires django to build some plugin api docs.