### PR TITLE
Add ability to update ci_update_branches from create-branch workflow

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -30,6 +30,7 @@ DEFAULT_SETTINGS = {
     "ci_trigger": "{pull_request: {branches: ['*']}}",
     "ci_update_branches": [],
     "ci_update_docs": False,
+    "ci_update_release_behavior": None,
     "core_import_allowed": [],
     "deploy_client_to_pypi": True,
     "deploy_client_to_rubygems": True,
@@ -218,6 +219,19 @@ def main():
                         """
         ),
     )
+    parser.add_argument(
+        "--add-version-ci-update-branches",
+        metavar="VERSION_BRANCH",
+        action="store",
+        help=textwrap.dedent(
+            """\
+                            Add specified version to the ci_update_branches before templating.
+                            This new value will replace the previous latest version if
+                            `ci_update_release_behavior` is set to 'replace-previous-version'.
+
+                        """
+        ),
+    )
     args = parser.parse_args()
 
     here = os.path.dirname(os.path.abspath(__file__))
@@ -270,6 +284,26 @@ def main():
                 config = generate_config(args.plugin_name, args.plugin_app_label)
         else:
             return 2
+
+    valid_release_behavior = [None, "append-version", "replace-previous-version"]
+    if config["ci_update_release_behavior"] not in valid_release_behavior:
+        valid_release_behavior[0] = "null"
+        print("ci_update_release_behavior is not of a valid value: ", valid_release_behavior)
+        return 2
+
+    if new_version_branch := args.add_version_ci_update_branches:
+        write_new_config = True
+        if config["ci_update_release_behavior"] == "replace-previous-version":
+            major_v, minor_v = new_version_branch.split(".", maxsplit=1)
+            minor_v = int(minor_v) - 1
+            try:
+                index = config["ci_update_branches"].index(f"{major_v}.{minor_v}")
+            except ValueError:
+                config["ci_update_branches"].append(new_version_branch)
+            else:
+                config["ci_update_branches"][index] = new_version_branch
+        else:
+            config["ci_update_branches"].append(new_version_branch)
 
     # Config key is used by the template_config.yml.j2 template to dump
     # the config. (note: uses .copy() to avoid a self reference)

--- a/templates/github/.github/workflows/create-branch.yml.j2
+++ b/templates/github/.github/workflows/create-branch.yml.j2
@@ -29,23 +29,23 @@ jobs:
 
       {{ setup_python(pyversion="3.8") | indent(6) }}
 
-      {{ install_python_deps("bump2version") | indent(6) }}
+      {{ install_python_deps("bump2version jinja2 pyyaml") | indent(6) }}
 
       {{ set_secrets() | indent(6) }}
 
       - name: Verify that branch name matches current version string on {{ plugin_default_branch }} branch
         run: |
           X_Y_VERSION=$(grep version setup.py | sed -rn 's/version="(.*)\.0((a[0-9]+)|(b[0-9]+))?\.dev",/\1/p' | awk '{$1=$1};1')
-          if [[ "$X_Y_VERSION" != "{{ "${{ github.event.inputs.name }}" }}" ]]
+          if [[ "$X_Y_VERSION" != "{{ "${{ inputs.name }}" }}" ]]
           then
             echo "Branch name doesn't match the current version string $X_Y_VERSION."
             exit 1
           fi
 
-      - name: Create {{ "${{ github.event.inputs.name }}" }} release branch
+      - name: Create {{ "${{ inputs.name }}" }} release branch
         run: |
-          git checkout -b {{ "${{ github.event.inputs.name }}" }}
-          git push origin {{ "${{ github.event.inputs.name }}" }}
+          git checkout -b {{ "${{ inputs.name }}" }}
+          git push origin {{ "${{ inputs.name }}" }}
 
       - name: Bump version on {{ plugin_default_branch }} branch
         run: |
@@ -55,7 +55,20 @@ jobs:
       - name: Remove entries from CHANGES directory
         run: |
           find CHANGES -type f -regex ".*\.\(bugfix\|doc\|feature\|misc\|deprecation\|removal\)" -exec git rm {} +
+{% if ci_update_release_behavior %}
+      - name: Checkout plugin template
+        uses: actions/checkout@v3
+        with:
+          repository: pulp/plugin_template
+          path: plugin_template
+          fetch-depth: 0
 
+      - name: Update CI branches in template_config
+        working-directory: plugin_template
+        run: |
+          python3 ./plugin-template {{ plugin_name }} --github --add-version-ci-update-branches {{ "${{ inputs.name }}" }}
+          git add -A
+{% endif %}
       - name: Make a PR with version bump and without CHANGES/*
         uses: peter-evans/create-pull-request@v4
         with:


### PR DESCRIPTION
~~Decided to add this functionality to the plugin-template script and have the create-branch workflow call with the new options if specified at dispatch time. Here is how the new dispatch screen looks:~~

![Screenshot from 2023-07-12 01-31-28](https://github.com/pulp/plugin_template/assets/28039189/97cc506f-ad9c-4bdc-b7f1-6a7ee70263e0)

Plugins have different behavior from pulpcore, some don't even set this variable, so I added three different options to cover each scenario.

*EDIT*
Changed it to a new template_config variable: `ci_update_release_behavior`.