### PR TITLE
Install requests for release script

### DIFF
--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -40,7 +40,7 @@ jobs:
 
       {{ setup_python(pyversion="3.8") | indent(6) }}
 
-      {{ install_python_deps("packaging~=21.3 bump2version gitpython towncrier==19.9.0 wheel") | indent(6) }}
+      {{ install_python_deps("packaging~=21.3 bump2version gitpython towncrier==19.9.0 wheel requests") | indent(6) }}
 
       {{ configure_git() | indent(6) }}
 


### PR DESCRIPTION
I am so used to always having requests be already installed that I kind of forgot it wasn't a standard library.