### PR TITLE
Changes where plugin_template is cloned to

### DIFF
--- a/templates/github/.github/workflows/create-branch.yml.j2
+++ b/templates/github/.github/workflows/create-branch.yml.j2
@@ -25,7 +25,10 @@ jobs:
       fail-fast: false
 
     steps:
-      {{ checkout() | indent(6) }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          path: {{ plugin_name }}
 
       {{ setup_python(pyversion="3.8") | indent(6) }}
 


### PR DESCRIPTION
This ensures that the plugin-template command looks for the template_config.yaml in the right place.

[noissue]