### PR TITLE
Automatic backport label creation kebab case support

### DIFF
--- a/CHANGES/788.bugfix
+++ b/CHANGES/788.bugfix
@@ -1,0 +1,2 @@
+Fixed automatic backport label creation, which only supported plugins whose names use snake_case
+naming convention.

--- a/templates/github/.github/workflows/scripts/update_backport_labels.py.j2
+++ b/templates/github/.github/workflows/scripts/update_backport_labels.py.j2
@@ -23,7 +23,7 @@ headers = {
 session.headers.update(headers)
 
 # get all labels from the repository's current state
-response = session.get("https://api.github.com/repos/pulp/{{ plugin_snake }}/labels", headers=headers)
+response = session.get("https://api.github.com/repos/pulp/{{ plugin_name }}/labels", headers=headers)
 assert response.status_code == 200
 old_labels = set([x["name"] for x in response.json() if x["name"].startswith("backport-")])
 


### PR DESCRIPTION
Github workflow automatically creating backport labels assumed all plugins' repositories use snake_case. This has now been fixed by introducing support for kebab-case named repositories too.

closes #788