### PR TITLE
Fix single commit workflow

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -30,7 +30,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Commit Count Check
-        run: echo "COMMIT_COUNT=$(git log  --oneline --no-merges origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | wc -l)" >> "$GITHUB_ENV"
+        run: |
+          git fetch origin ${{ github.event.pull_request.head.sha }}
+          echo "COMMIT_COUNT=$(git log  --oneline --no-merges origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | wc -l)" >> "$GITHUB_ENV"
       - uses: actions/github-script@v7
         with:
           script: |

--- a/templates/github/.github/workflows/pr_checks.yml.j2
+++ b/templates/github/.github/workflows/pr_checks.yml.j2
@@ -26,7 +26,9 @@ jobs:
     steps:
       {{ checkout(0) | indent(6) }}
       - name: Commit Count Check
-        run: {{ 'echo "COMMIT_COUNT=$(git log  --oneline --no-merges origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | wc -l)" >> "$GITHUB_ENV"' }}
+        run: |
+          git fetch origin {{ '${{ github.event.pull_request.head.sha }}' }}
+          {{ 'echo "COMMIT_COUNT=$(git log  --oneline --no-merges origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | wc -l)" >> "$GITHUB_ENV"' }}
       - uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
It turned out that even using fetch-depth: 0 does not include fetching PR commits when the PR branch is in a different fork.

[noissue]