### PR TITLE
Fix nightly by calling the build workflow

### DIFF
--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -26,8 +26,12 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
   test:
     runs-on: ubuntu-latest
+    needs: build
 
     strategy:
       fail-fast: false
@@ -55,6 +59,11 @@ jobs:
 
     steps:
       {{ checkout() | indent(6) }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: plugin_package
+          path: dist/
 
       {{ setup_python() | indent(6) }}
 
@@ -142,6 +151,11 @@ jobs:
 
     steps:
       {{ checkout() | indent(6) }}
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: plugin_package
+          path: dist/
 
       {{ setup_python() | indent(6) }}
 


### PR DESCRIPTION
This is the minimal fix needed. To transform the nightly CI to fully leverage the reusable workflows, there is a need for more thinking.

[noissue]