### PR TITLE
Fix single commit check when label did not exist

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -37,14 +37,18 @@ jobs:
         with:
           script: |
             const { COMMIT_COUNT } = process.env
+
             if (COMMIT_COUNT == 1)
             {
-              github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: ["multi-commit"]
-              })
+              try {
+                github.rest.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: ["multi-commit"]
+                })
+              } catch(err) {
+              }
             }
             else
             {

--- a/templates/github/.github/workflows/pr_checks.yml.j2
+++ b/templates/github/.github/workflows/pr_checks.yml.j2
@@ -33,14 +33,18 @@ jobs:
         with:
           script: |
             const { COMMIT_COUNT } = process.env
+
             if (COMMIT_COUNT == 1)
             {
-              github.rest.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: ["multi-commit"]
-              })
+              try {
+                github.rest.issues.removeLabel({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: ["multi-commit"]
+                })
+              } catch(err) {
+              }
             }
             else
             {


### PR DESCRIPTION
The call to remove a label from a PR fails with 404 if that label did not exist. We can ignore this error.

[noissue]