### PR TITLE
Remove option for single commit check

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,6 @@ The following settings are stored in `template_config.yml`.
 
   noissue_marker        A string that is used to mark a commit as not attached to an issue.
 
-  single_commit_check   Runs a job to check whether a PR contains a single commit or not.
-
   stalebot              A boolean that indicates whether to use stalebot or not.
 
   stalebot_days_until_stale

--- a/plugin-template
+++ b/plugin-template
@@ -69,7 +69,6 @@ DEFAULT_SETTINGS = {
     "python_version": "3.8",
     "release_email": "pulp-infra@redhat.com",
     "release_user": "pulpbot",
-    "single_commit_check": True,
     "stalebot_days_until_close": 30,
     "stalebot_days_until_stale": 90,
     "stalebot_limit_to_pulls": True,

--- a/templates/github/.github/workflows/pr_checks.yml.j2
+++ b/templates/github/.github/workflows/pr_checks.yml.j2
@@ -3,7 +3,6 @@
   checkout,
 with context %}
 ---
-{%- if single_commit_check %}
 name: {{ plugin_app_label | camel }} PR static checks
 on:
   pull_request_target:
@@ -56,4 +55,3 @@ jobs:
                 labels: [labelName],
               });
             }
-{%- endif %}


### PR DESCRIPTION
The new version of this check is no longer intimidating, and switching off this option leads to an invalid workflow file.

[noissue]