### PR TITLE
Use a better key for the static PR check

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -16,7 +16,7 @@ on:
 # Static analysis should be fine however.
 
 concurrency:
-  group: ${{ github.ref_name }}-${{ github.workflow }}
+  group: ${{ github.event.pull_request.number }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:

--- a/templates/github/.github/workflows/pr_checks.yml.j2
+++ b/templates/github/.github/workflows/pr_checks.yml.j2
@@ -13,7 +13,7 @@ on:
 # Static analysis should be fine however.
 
 concurrency:
-  group: {{ '${{ github.ref_name }}-${{ github.workflow }}' }}
+  group: {{ '${{ github.event.pull_request.number }}-${{ github.workflow }}' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Since this workflowruns against main, the ref_name is not suitable for a cancellation condition.

[noissue]