### PR TITLE
Remove workaround not publishing pulp-file client

### DIFF
--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -58,11 +58,23 @@ then
     sudo rm -rf "./${item}-client"
   done
   popd
-  touch bindings_requirements.txt
 else
-  echo "$REPORTED_STATUS" | jq -r '.versions[]|(.package|sub("_"; "-")) + "-client==" + .version' > bindings_requirements.txt
+  # Sadly: Different pulpcore-versions aren't either...
+  pushd ../pulp-openapi-generator
+  for item in $(echo "$REPORTED_STATUS" | jq -r '.versions[]
+    {%- for plugin in plugins -%}
+    |select(.component!="{{ plugin.app_label }}")
+    {%- endfor -%}
+    .package|sub("-"; "_")')
+  do
+    ./generate.sh "${item}" python
+    cmd_prefix pip3 install "/root/pulp-openapi-generator/${item}-client"
+    sudo rm -rf "./${item}-client"
+  done
+  popd
 fi
 
+echo "$REPORTED_STATUS" | jq -r '.versions[]|(.package|sub("_"; "-")) + "-client==" + .version' > bindings_requirements.txt
 cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt" < unittest_requirements.txt
 cmd_stdin_prefix bash -c "cat > /tmp/functest_requirements.txt" < functest_requirements.txt
 cmd_stdin_prefix bash -c "cat > /tmp/bindings_requirements.txt" < bindings_requirements.txt

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -60,10 +60,7 @@ then
   popd
   touch bindings_requirements.txt
 else
-  # TODO Workaround us not publishing pulp_file clients currently
-  echo "$REPORTED_STATUS" | jq -r '.versions[]|(.package|sub("_"; "-")) + "-client==" + .version' | grep -v pulp-file > bindings_requirements.txt
-  echo "pulp-file-client" >> bindings_requirements.txt
-  # echo "$REPORTED_STATUS" | jq -r '.versions[]|(.package|sub("_"; "-")) + "-client==" + .version' > bindings_requirements.txt
+  echo "$REPORTED_STATUS" | jq -r '.versions[]|(.package|sub("_"; "-")) + "-client==" + .version' > bindings_requirements.txt
 fi
 
 cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt" < unittest_requirements.txt


### PR DESCRIPTION
Since we can now publish clients for multiple plugins in one repository, this workaround is not needed anymore. Also it turned out to be evil on older pulpcore branches by installing the wrong version of the bindings.

[noissue]