### PR TITLE
Fix nightly workflow syntax

### DIFF
--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -33,7 +33,6 @@ jobs:
     uses: "./.github/workflows/build.yml"
 
   test:
-    runs-on: "ubuntu-latest"
     needs: "build"
     uses: "./.github/workflows/test.yml"
 


### PR DESCRIPTION
When delegating to another workflow with uses, you cannot use a lot of the other parameters.

[noissue]