### PR TITLE
Fix update ci workflow

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -373,7 +373,12 @@ def write_template_section(config, name, plugin_root_dir, verbose=False):
 
     files_templated = 0
     files_copied = 0
-    gitref = subprocess.check_output(["git", "describe", "--dirty"]).decode().strip()
+
+    try:
+        gitref = subprocess.check_output(["git", "describe", "--dirty"]).decode().strip()
+    except Exception:
+        gitref = "unknown"
+
     for relative_path in generate_relative_path_set(section_template_dir):
         if not config["stalebot"] and "stale" in relative_path:
             continue

--- a/plugin-template
+++ b/plugin-template
@@ -3,6 +3,7 @@
 import argparse
 import os
 import pprint
+import shlex
 import shutil
 import stat
 import subprocess
@@ -363,13 +364,16 @@ def write_template_section(config, name, plugin_root_dir, verbose=False):
                 "templates",  # The default templates folder
                 "../",  # The parent dir to allow including pre/post templates from
             ]
-        )
+        ),
+        line_statement_prefix="§=",
+        line_comment_prefix="§#",
     )
     env.filters["camel"] = utils.to_camel
     env.filters["caps"] = utils.to_caps
     env.filters["dash"] = utils.to_dash
     env.filters["snake"] = utils.to_snake
     env.filters["to_yaml"] = to_nice_yaml
+    env.filters["shquote"] = shlex.quote
 
     files_templated = 0
     files_copied = 0

--- a/templates/github/.github/workflows/changelog.yml.j2
+++ b/templates/github/.github/workflows/changelog.yml.j2
@@ -28,7 +28,7 @@ jobs:
 
       {{ setup_python() | indent(6) }}
 
-      {{ install_python_deps(deps=["-r doc_requirements.txt"]) | indent(6) }}
+      {{ install_python_deps(deps=["-r", "doc_requirements.txt"]) | indent(6) }}
 
       - name: "Fake api schema"
         run: |

--- a/templates/github/.github/workflows/lint.yml.j2
+++ b/templates/github/.github/workflows/lint.yml.j2
@@ -25,7 +25,7 @@ jobs:
 
       {{ setup_python() | indent(6) }}
 
-      {{ install_python_deps(["-r lint_requirements.txt"]) | indent(6) }}
+      {{ install_python_deps(["-r", "lint_requirements.txt"]) | indent(6) }}
 
       - name: Lint workflow files
         run: |

--- a/templates/github/.github/workflows/update_ci.yml.j2
+++ b/templates/github/.github/workflows/update_ci.yml.j2
@@ -25,7 +25,9 @@ jobs:
       fail-fast: false
 
     steps:
-      {{ checkout(repository="pulp/plugin_template", path="plugin_template") | indent(6) }}
+      {#- "depth=0" is needed to run "git describe". #}
+      {{ checkout(repository="pulp/plugin_template", path="plugin_template", depth=0) | indent(6) }}
+
       {{ setup_python() | indent(6) }}
 
       {{ install_python_deps(["gitpython", "requests", "packaging", "jinja2", "pyyaml"]) | indent(6) }}

--- a/templates/macros.j2
+++ b/templates/macros.j2
@@ -51,10 +51,10 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
 - name: "Install python dependencies"
   run: |
     echo ::group::PYDEPS
-    pip install {{ deps | join(" ") }}
-    {%- if 'httpie' in deps %}
+    pip install {{ deps | map("shquote") | join(" ") }}
+    §= if 'httpie' in deps
     echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/{{ plugin_name }}/.ci/assets/httpie/" >> $GITHUB_ENV
-    {%- endif %}
+    §= endif
     echo ::endgroup::
 {%- endmacro -%}
 


### PR DESCRIPTION
We actually need the git history in order to use git describe. Since this change prevented further CI updates, the call to plugin template has been made resilient to this failure.

[noissue]