### PR TITLE
Fix call to towncrier

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -124,16 +124,16 @@ DEPRECATED_FILES = {
 def main():
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description="Create or update a plugin using the current " "template.",
+        description="Create or update a plugin using the current template.",
     )
     parser.add_argument(
         "plugin_name",
         type=str,
         help=textwrap.dedent(
             """\
-                            Create or update this plugin. The name should start with pulp- or pulp_.
+                Create or update this plugin. The name should start with pulp- or pulp_.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -141,10 +141,9 @@ def main():
         type=str,
         help=textwrap.dedent(
             """\
-                            the Django app label for the plugin - usually the part after pulp_ or
-                            pulp-.
+                the Django app label for the plugin - usually the part after pulp_ or pulp-.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -152,9 +151,9 @@ def main():
         action="store_true",
         help=textwrap.dedent(
             """\
-                            Create or update a plugin template config for a plugin and exit.
+                Create or update a plugin template config for a plugin and exit.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -162,9 +161,9 @@ def main():
         action="store_true",
         help=textwrap.dedent(
             """\
-                            Create a new plugin and template boilerplate code.
+                Create a new plugin and template boilerplate code.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -172,9 +171,9 @@ def main():
         action="store_true",
         help=textwrap.dedent(
             """\
-                            Generate or update functional and unit tests.
+                Generate or update functional and unit tests.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -182,9 +181,9 @@ def main():
         action="store_true",
         help=textwrap.dedent(
             """\
-                            Generate or update github CI/CD configuration files.
+                Generate or update github CI/CD configuration files.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -192,9 +191,9 @@ def main():
         action="store_true",
         help=textwrap.dedent(
             """\
-                            Generate or update plugin documentation.
+                Generate or update plugin documentation.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -202,9 +201,9 @@ def main():
         action="store_true",
         help=textwrap.dedent(
             """\
-                            Create a new plugin and template all non-excluded files.
+                Create a new plugin and template all non-excluded files.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -212,9 +211,9 @@ def main():
         action="store_true",
         help=textwrap.dedent(
             """\
-                            Include more output.
+                Include more output.
 
-                        """
+            """
         ),
     )
     parser.add_argument(
@@ -223,11 +222,11 @@ def main():
         action="store",
         help=textwrap.dedent(
             """\
-                            Add specified version to the ci_update_branches before templating.
-                            This new value will replace the previous latest version if
-                            `ci_update_release_behavior` is set to 'replace-previous-version'.
+                Add specified version to the ci_update_branches before templating.
+                This new value will replace the previous latest version if
+                `ci_update_release_behavior` is set to 'replace-previous-version'.
 
-                        """
+            """
         ),
     )
     args = parser.parse_args()
@@ -365,8 +364,8 @@ def write_template_section(config, name, plugin_root_dir, verbose=False):
                 "../",  # The parent dir to allow including pre/post templates from
             ]
         ),
-        line_statement_prefix="§=",
-        line_comment_prefix="§#",
+        line_statement_prefix="%%",
+        line_comment_prefix="%#",
     )
     env.filters["camel"] = utils.to_camel
     env.filters["caps"] = utils.to_caps

--- a/templates/github/.flake8.j2
+++ b/templates/github/.flake8.j2
@@ -1,9 +1,6 @@
 {% include 'header.j2' %}
 [flake8]
-exclude = ./docs/*,*/migrations/*
-{%- for item in flake8_ignore %}
-{{- "," + item }}
-{% endfor %}
+exclude = {{ (["./docs/*", "*/migrations/*"] + flake8_ignore) | join(",") }}
 per-file-ignores = */__init__.py: F401
 
 ignore = E203,W503,Q000,Q003,D100,D104,D106,D200,D205,D400,D401,D402

--- a/templates/github/.github/workflows/scripts/release.py.j2
+++ b/templates/github/.github/workflows/scripts/release.py.j2
@@ -43,7 +43,7 @@ def create_release_commits(repo, release_version, plugin_path):
 
     issues = ",".join(issues_to_close)
     # First commit: changelog
-    os.system(f"towncrier --yes --version {release_version}")
+    os.system(f"towncrier build --yes --version {release_version}")
     git = repo.git
     git.add("CHANGES.rst")
     git.add("CHANGES/*")

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -24,7 +24,7 @@ export PULP_URL="{{ pulp_scheme }}://pulp"
 
 if [[ "$TEST" = "docs" ]]; then
   if [[ "$GITHUB_WORKFLOW" == "{{ plugin_app_label | camel | default("Pulp") }} CI" ]]; then
-    towncrier --yes --version 4.0.0.ci
+    towncrier build --yes --version 4.0.0.ci
   fi
   cd docs
   make PULP_URL="$PULP_URL" diagrams html

--- a/templates/github/.github/workflows/update_ci.yml.j2
+++ b/templates/github/.github/workflows/update_ci.yml.j2
@@ -25,8 +25,7 @@ jobs:
       fail-fast: false
 
     steps:
-      {#- "depth=0" is needed to run "git describe". #}
-      {{ checkout(repository="pulp/plugin_template", path="plugin_template", depth=0) | indent(6) }}
+      {{ checkout(repository="pulp/plugin_template", path="plugin_template", depth=0) | indent(6) }} %# "depth=0" is needed to run "git describe".
 
       {{ setup_python() | indent(6) }}
 

--- a/templates/macros.j2
+++ b/templates/macros.j2
@@ -52,9 +52,9 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
   run: |
     echo ::group::PYDEPS
     pip install {{ deps | map("shquote") | join(" ") }}
-    §= if 'httpie' in deps
+    %% if 'httpie' in deps
     echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/{{ plugin_name }}/.ci/assets/httpie/" >> $GITHUB_ENV
-    §= endif
+    %% endif
     echo ::endgroup::
 {%- endmacro -%}
 
@@ -96,7 +96,7 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
   if: "{{ condition }}"
   {%- endif %}
   run: |
-    .github/workflows/scripts/{{ file }}
+    {{ (".github/workflows/scripts/" + file) | shquote }}
   shell: "bash"
   {%- if withenv %}
   env:


### PR DESCRIPTION
[noissue]

Turned out that "§" is not accessible on some keyboard alyouts. I was wondering why no programming language had used that character before...

Towncrier stops to perform the default `build` subcommand, once you
specify '--version'. So we need to explicitely do 'towncrier build ...'
That's probably the reason why we had it pinned to that old version.