### PR TITLE
Fixup client docs building

### DIFF
--- a/templates/github/.github/workflows/scripts/install_python_client.sh.j2
+++ b/templates/github/.github/workflows/scripts/install_python_client.sh.j2
@@ -48,7 +48,8 @@ DOCSYAML
 # Building the bindings docs
 mkdocs build
 
-tar cvf ../../{{ plugin_name }}/{{ plugin.app_label }}-python-client-docs.tar ./docs
+# Pack the built site.
+tar cvf ../../{{ plugin_name }}/{{ plugin.app_label }}-python-client-docs.tar ./site
 popd
 {%- endfor %}
 popd


### PR DESCRIPTION
Instead of the docs directory, after building, we should pack up the site directory.

[noissue]