### PR TITLE
Add a ready-to-ship check that depends all jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ defaults:
     working-directory: "pulp_catdog"
 
 jobs:
-  ready-to-ship:
+  check-commits:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v4"
@@ -78,3 +78,19 @@ jobs:
         run: |
           cat deprecations-*.txt | sort -u
           ! cat deprecations-*.txt | grep '[^[:space:]]'
+
+  ready-to-ship:
+    # This is a dummy dependent task to have a single entry for the branch protection rules.
+    runs-on: "ubuntu-latest"
+    needs:
+      - "check-commits"
+      - "lint"
+      - "test"
+    if: "always()"
+    steps:
+      - name: "Collect needed jobs results"
+        working-directory: "."
+        run: |
+          echo '${{toJson(needs)}}' | jq -r 'to_entries[]|select(.value.result!="success")|.key + ": " + .value.result'
+          echo '${{toJson(needs)}}' | jq -e 'to_entries|map(select(.value.result!="success"))|length == 0'
+          echo "CI says: Looks good!"

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -22,7 +22,7 @@ jobs:
   {% include pre_job_template.path %}
   {%- endif %}
   {%- if check_commit_message or lint_requirements %}
-  ready-to-ship:
+  check-commits:
     runs-on: "ubuntu-latest"
     steps:
       {{ checkout(depth=0, path=plugin_name) | indent(6) }}
@@ -73,9 +73,23 @@ jobs:
         run: |
           cat deprecations-*.txt | sort -u
           ! cat deprecations-*.txt | grep '[^[:space:]]'
-
   {%- endif %}
 
+  ready-to-ship:
+    # This is a dummy dependent task to have a single entry for the branch protection rules.
+    runs-on: "ubuntu-latest"
+    needs:
+      - "check-commits"
+      - "lint"
+      - "test"
+    if: "always()"
+    steps:
+      - name: "Collect needed jobs results"
+        working-directory: "."
+        run: |
+          echo {{ "'${{toJson(needs)}}'" }} | jq -r 'to_entries[]|select(.value.result!="success")|.key + ": " + .value.result'
+          echo {{ "'${{toJson(needs)}}'" }} | jq -e 'to_entries|map(select(.value.result!="success"))|length == 0'
+          echo "CI says: Looks good!"
 {%- if post_job_template %}
   {% include post_job_template.path %}
 {%- endif %}


### PR DESCRIPTION
This is a dummy job that depends on all other test runs, so declaring a single required job in the branch protection rules is sufficient. Also this allows to add and remove scenarios to/from our CI via a pull request. And we can use the same rules for all release branches having different scenarios.

[noissue]