### PR TITLE
Fix a dependency on a non existing job

### DIFF
--- a/templates/github/.github/workflows/build.yml.j2
+++ b/templates/github/.github/workflows/build.yml.j2
@@ -16,9 +16,6 @@ defaults:
 jobs:
   build:
     runs-on: "ubuntu-latest"
-    {%- if pre_job_template %}
-    needs: "{{ pre_job_template.name }}"
-    {%- endif %}
 
     steps:
       {{ checkout(path=plugin_name) | indent(6) }}

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -44,6 +44,9 @@ jobs:
   {%- endif %}
 
   lint:
+    {%- if pre_job_template %}
+    needs: {{ pre_job_template.name }}
+    {%- endif %}
     uses: "./.github/workflows/lint.yml"
 
   build:
@@ -79,7 +82,9 @@ jobs:
     # This is a dummy dependent task to have a single entry for the branch protection rules.
     runs-on: "ubuntu-latest"
     needs:
+      {%- if check_commit_message or lint_requirements %}
       - "check-commits"
+      {%- endif %}
       - "lint"
       - "test"
     if: "always()"

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   {%- if pre_job_template %}
-  {% include pre_job_template.path %}
+  {% include pre_job_template.path | indent(2) %}
   {%- endif %}
   {%- if check_commit_message or lint_requirements %}
   check-commits:
@@ -96,5 +96,5 @@ jobs:
           echo {{ "'${{toJson(needs)}}'" }} | jq -e 'to_entries|map(select(.value.result!="success"))|length == 0'
           echo "CI says: Looks good!"
 {%- if post_job_template %}
-  {% include post_job_template.path %}
+  {% include post_job_template.path | indent (2) %}
 {%- endif %}

--- a/templates/github/.github/workflows/lint.yml.j2
+++ b/templates/github/.github/workflows/lint.yml.j2
@@ -16,9 +16,6 @@ defaults:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    {%- if pre_job_template %}
-    needs: {{ pre_job_template.name }}
-    {%- endif %}
 
     steps:
       {{ checkout(path=plugin_name) | indent(6) }}


### PR DESCRIPTION
When you configured your plugin template to not check commit messages, there's no way you can depend on that job.

[noissue]