### PR TITLE
Remove extras from the lowerbounds constraints

### DIFF
--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -62,6 +62,7 @@ fi
 
 if [[ "$TEST" = "lowerbounds" ]]; then
   python3 .ci/scripts/calc_deps_lowerbounds.py > lowerbounds_constraints.txt
+  sed -i 's/\[.*\]//g' lowerbounds_constraints.txt
 fi
 
 if [ -f $POST_BEFORE_INSTALL ]; then


### PR DESCRIPTION
This fixes the "Constraints cannot have extras" error observed in the pulp-container's CI (https://github.com/pulp/pulp_container/pull/1441).

The workaround was taken from https://github.com/jazzband/pip-tools/issues/1300#issuecomment-818122483.

[noissue]