### PR TITLE
Use RELEASE_TOKEN for releasing

### DIFF
--- a/CHANGES/833.bugfix
+++ b/CHANGES/833.bugfix
@@ -1,0 +1,1 @@
+Use RELEASE_TOKEN for git operations in the release process.

--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
 
     steps:
-      {{ checkout(depth=0, path=plugin_name) | indent(6) }}
+      {{ checkout(depth=0, path=plugin_name, use_release_token=true) | indent(6) }}
 
       {{ setup_python(pyversion="3.8") | indent(6) }}
 

--- a/templates/macros.j2
+++ b/templates/macros.j2
@@ -14,7 +14,7 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
 {%- endmacro -%}
 
 
-{%- macro checkout(depth=1, repository=None, path=None, ref=None) -%}
+{%- macro checkout(depth=1, repository=None, path=None, ref=None, use_release_token=false) -%}
 - uses: "actions/checkout@v4"
   with:
     fetch-depth: {{ depth }}
@@ -26,6 +26,9 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
     {%- endif %}
     {%- if ref %}
     ref: "{{ ref }}"
+    {%- endif %}
+    {%- if use_release_token %}
+    token: {{ "${{ secrets.RELEASE_TOKEN }}" }}
     {%- endif %}
 {%- endmacro -%}
 


### PR DESCRIPTION
When pushing with the default workflow token, you would need to disable the branch protection and the subsequent publish workflow will not trigger.

Fixes #833