### PR TITLE
Install the packaging dependency

### DIFF
--- a/templates/github/.github/workflows/create-branch.yml.j2
+++ b/templates/github/.github/workflows/create-branch.yml.j2
@@ -25,7 +25,7 @@ jobs:
 
       {{ setup_python(pyversion="3.8") | indent(6) }}
 
-      {{ install_python_deps(["bump2version", "jinja2", "pyyaml"]) | indent(6) }}
+      {{ install_python_deps(["bump2version", "jinja2", "pyyaml", "packaging"]) | indent(6) }}
 
       {{ set_secrets(path=plugin_name) | indent(6) }}
 


### PR DESCRIPTION
Fixes failures like:
```
  File "./plugin-template", line 18, in <module>
    from packaging.requirements import Requirement
ModuleNotFoundError: No module named 'packaging'
```

[noissue]