### PR TITLE
Update patched botocore for S3 runner to latest version

### DIFF
--- a/templates/github/.ci/ansible/Containerfile.j2.copy
+++ b/templates/github/.ci/ansible/Containerfile.j2.copy
@@ -11,7 +11,7 @@ ADD ./{{ item.name }} ./{{ item.name }}
 
 RUN pip3 install
 {%- if s3_test | default(false) -%}
-{{ " " }}git+https://github.com/fabricio-aguiar/botocore.git@fix-100-continue
+{{ " " }}git+https://github.com/gerrod3/botocore.git@fix-100-continue
 {%- endif -%}
 {%- for item in plugins -%}
 {{ " " }}{{ item.source }}


### PR DESCRIPTION
The current patched botocore we are using is ~20 versions behind latest. A test dependency in pulp_python is clashing with botocore over a shared dependency (urlib3), causing botocore to become broken and break the S3 runner. Updating to the latest fixes this: https://github.com/pulp/pulp_python/pull/643