### PR TITLE
Allow ci_base image to be configurable

### DIFF
--- a/CHANGES/843.feature
+++ b/CHANGES/843.feature
@@ -1,0 +1,1 @@
+Allow CI base image to be configured with `ci_base_image`.

--- a/plugin-template
+++ b/plugin-template
@@ -27,6 +27,7 @@ DEFAULT_SETTINGS = {
     "check_stray_pulpcore_imports": True,
     "cli_package": "pulp-cli",
     "cli_repo": "https://github.com/pulp/pulp-cli.git",
+    "ci_base_image": "ghcr.io/pulp/pulp-ci-centos",
     "ci_env": {},
     "ci_trigger": "{pull_request: {branches: ['*']}}",
     "ci_update_docs": False,

--- a/templates/github/.ci/ansible/Containerfile.j2.copy
+++ b/templates/github/.ci/ansible/Containerfile.j2.copy
@@ -1,4 +1,4 @@
-FROM {{ ci_base | default("ghcr.io/pulp/pulp-ci-centos:" + pulp_container_tag) }}
+FROM {{ ci_base | default(pulp_default_container) }}
 
 # Add source directories to container
 {% for item in plugins %}

--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -96,11 +96,11 @@ cat >> vars/main.yaml << VARSYAML
 pulp_env: {{ pulp_env | tojson }}
 pulp_settings: {{ pulp_settings | tojson }}
 pulp_scheme: {{ pulp_scheme }}
-{% if python_version == "3.6" %}
-pulp_container_tag: "python36"
+{%- if ci_base_image.count(":") %}
+pulp_default_container: {{ ci_base_image }}
 {% else %}
-pulp_container_tag: "latest"
-{% endif %}
+pulp_default_container: {{ ci_base_image + ":latest" }}
+{% endif -%}
 VARSYAML
 
 {%- if docker_fixtures %}


### PR DESCRIPTION
This will allow us to switch our latest branches to the new centos9 ci images (https://github.com/pulp/pulp-oci-images/pull/592), without breaking our older branches.

fixes: #843