### PR TITLE
Allow repositories without plugins

### DIFF
--- a/templates/github/.ci/ansible/start_container.yaml
+++ b/templates/github/.ci/ansible/start_container.yaml
@@ -83,22 +83,14 @@
           command: "docker logs pulp"
           failed_when: true
 
-    - block:
-        - name: "Check version of component being tested"
-          assert:
-            that:
-              - (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] | canonical_semver == (component_version | canonical_semver)
-            fail_msg: |
-              Component {{ component_name }} was expected to be installed in version {{ component_version }}.
-              Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] }}.
-      rescue:
-        - name: "Check version of component being tested (legacy)"
-          assert:
-            that:
-              - (result.json.versions | items2dict(key_name="component", value_name="version"))[legacy_component_name] | canonical_semver == (component_version | canonical_semver)
-            fail_msg: |
-              Component {{ legacy_component_name }} was expected to be installed in version {{ component_version }}.
-              Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[legacy_component_name] }}.
+    - name: "Check version of component being tested"
+      assert:
+        that:
+          - (result.json.versions | items2dict(key_name="component", value_name="version"))[item.app_label] | canonical_semver == (component_version | canonical_semver)
+        fail_msg: |
+          Component {{ item.app_label }} was expected to be installed in version {{ component_version }}.
+          Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[item.app_label] }}.
+      loop: "{{ 'plugins' | ansible.builtin.extract(lookup('ansible.builtin.file', '../../template_config.yml') | from_yaml) }}"
 
     - name: "Set pulp password in .netrc"
       copy:

--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -11,7 +11,7 @@ set -euv
 source .github/workflows/scripts/utils.sh
 
 PLUGIN_VERSION="$(sed -n -e 's/^\s*current_version\s*=\s*//p' .bumpversion.cfg | python -c 'from packaging.version import Version; print(Version(input()))')"
-PLUGIN_NAME="./{{ plugin_name }}/dist/{{ plugin_name | snake }}-${PLUGIN_VERSION}-py3-none-any.whl"
+PLUGIN_SOURCE="./{{ plugin_name }}/dist/{{ plugin_name | snake }}-${PLUGIN_VERSION}-py3-none-any.whl"
 
 export PULP_API_ROOT="{{ api_root }}"
 
@@ -40,7 +40,6 @@ fi
 cd .ci/ansible/
 
 {%- set PULPCORE_PREFIX = "" if plugin_name == "pulpcore" else " pulpcore" %}
-PLUGIN_SOURCE="${PLUGIN_NAME}"
 {%- if test_s3 %}
 if [ "$TEST" = "s3" ]; then
   PLUGIN_SOURCE="${PLUGIN_SOURCE}{{ PULPCORE_PREFIX }}[s3]"

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -138,6 +138,7 @@ cmd_user_prefix bash -c "django-admin makemigrations {{ plugin.app_label }} --ch
 cmd_user_prefix bash -c "PULP_DATABASES__default__USER=postgres pytest -v -r sx --color=yes --suppress-no-test-exit-code -p no:pulpcore --pyargs {{ plugin.name | snake }}.tests.unit"
 {%- endfor %}
 
+{%- if plugins %}
 # Run functional tests
 if [[ "$TEST" == "performance" ]]; then
   if [[ -z ${PERFORMANCE_TEST+x} ]]; then
@@ -175,8 +176,9 @@ export PULP_FIXTURES_URL="http://pulp-fixtures:8080"
 {%- endif %}
 pushd ../{{ cli_package }}
 pip install -r test_requirements.txt
-pytest -v -m {{ plugin_name | snake }}
+pytest -v -m "{{ plugins | map(attribute='name') | join(' or ') | snake }}"
 popd
+{%- endif %}
 {%- endif %}
 
 if [ -f "$POST_SCRIPT" ]; then


### PR DESCRIPTION
As programmers we start counting at 0. If a repository can house more than one plugin, no plugin should be a valid assumption too.

[noissue]