### PR TITLE
Fix dependency issues triggered when installing the openapi extension

### DIFF
--- a/templates/docs/docs/conf.py.j2
+++ b/templates/docs/docs/conf.py.j2
@@ -42,7 +42,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
-    'sphinxcontrib.openapi',
     'sphinxcontrib.jquery',
     {%- if plugin_name == "pulpcore" %}
     'napoleon_django',


### PR DESCRIPTION
This removal fixes the following error:
Could not import extension sphinxcontrib.openapi (exception: cannot import name 'error_string' from 'docutils.io' (/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/site-packages/docutils/io.py))

[noissue]