### PR TITLE
Combine artifact uploads in the publish workflow

### DIFF
--- a/templates/github/.github/workflows/publish.yml.j2
+++ b/templates/github/.github/workflows/publish.yml.j2
@@ -62,12 +62,14 @@ jobs:
       {{ run_script(name="Install Ruby client", file="install_ruby_client.sh", withenv=False) | indent(6) }}
       {%- endif %}
 
-      {%- for plugin in plugins %}
       - name: "Upload python client packages"
         uses: "actions/upload-artifact@v4"
         with:
           name: "python-client.tar"
-          path: "{{ plugin_name }}/{{ plugin.app_label }}-python-client.tar"
+          path: |
+            {%- for plugin in plugins %}
+            {{ plugin_name }}/{{ plugin.app_label }}-python-client.tar
+            {%- endfor %}
           if-no-files-found: "error"
           overwrite: true
 
@@ -75,7 +77,10 @@ jobs:
         uses: "actions/upload-artifact@v4"
         with:
           name: "python-client-docs.tar"
-          path: "{{ plugin_name }}/{{ plugin.app_label }}-python-client-docs.tar"
+          path: |
+            {%- for plugin in plugins %}
+            {{ plugin_name }}/{{ plugin.app_label }}-python-client-docs.tar
+            {%- endfor %}
           if-no-files-found: "error"
           overwrite: true
 
@@ -84,11 +89,13 @@ jobs:
         uses: "actions/upload-artifact@v4"
         with:
           name: "ruby-client.tar"
-          path: "{{ plugin_name }}/{{ plugin.app_label }}-ruby-client.tar"
+          path: |
+            {%- for plugin in plugins %}
+            {{ plugin_name }}/{{ plugin.app_label }}-ruby-client.tar
+            {%- endfor %}
           if-no-files-found: "error"
           overwrite: true
       {%- endif %}
-      {%- endfor %}
 
       {%- if publish_docs_to_pulpprojectdotorg %}
       - name: Build docs

--- a/templates/github/.github/workflows/scripts/publish_client_pypi.sh.j2
+++ b/templates/github/.github/workflows/scripts/publish_client_pypi.sh.j2
@@ -13,18 +13,16 @@ if [[ -z "$VERSION" ]]; then
   echo "No version specified."
   exit 1
 fi
+{%- for plugin in plugins %}
 
-RESPONSE="$(curl --write-out '%{http_code}' --silent --output /dev/null "https://pypi.org/project/{{ plugin_name | dash }}-client/$VERSION/")"
+RESPONSE="$(curl --write-out '%{http_code}' --silent --output /dev/null "https://pypi.org/project/{{ plugin.name | dash }}-client/$VERSION/")"
 
 if [ "$RESPONSE" == "200" ];
 then
-  echo "{{ plugin_name }} client $VERSION has already been released. Skipping."
-  exit
+  echo "{{ plugin.name }} client $VERSION has already been released. Skipping."
+else
+  twine upload -u __token__ -p "$PYPI_API_TOKEN" \
+  "dist/{{ plugin.name | snake }}_client-$VERSION-py3-none-any.whl" \
+  "dist/{{ plugin.name | snake }}-client-$VERSION.tar.gz"
 fi
-
-twine upload -u __token__ -p "$PYPI_API_TOKEN" \
-{%- for plugin in plugins %}
-"dist/{{ plugin.name | snake }}_client-$VERSION-py3-none-any.whl" \
-"dist/{{ plugin.name | snake }}-client-$VERSION.tar.gz" \
 {%- endfor %}
-;


### PR DESCRIPTION
The new (v4) version of the upload artifact action no longer supports adding files to existing artifacts. But since we have all files lying around anyway we can just consolidate on a single upload action for each type of publish artifact.

[noissue]