### PR TITLE
Stop installing lsof and which

### DIFF
--- a/templates/github/.github/workflows/scripts/before_script.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_script.sh.j2
@@ -31,12 +31,6 @@ tail -v -n +1 .ci/ansible/Containerfile
 cmd_prefix bash -c "echo '%wheel        ALL=(ALL)       NOPASSWD: ALL' > /etc/sudoers.d/nopasswd"
 cmd_prefix bash -c "usermod -a -G wheel pulp"
 
-SCENARIOS=("pulp" "performance" "azure" "gcp" "s3" "generate-bindings" "lowerbounds")
-if [[ " ${SCENARIOS[*]} " =~ " ${TEST} " ]]; then
-  # Many functional tests require these
-  cmd_prefix dnf install -yq lsof which
-fi
-
 if [[ "${REDIS_DISABLED:-false}" == true ]]; then
   cmd_prefix bash -c "s6-rc -d change redis"
   echo "The Redis service was disabled for $TEST"


### PR DESCRIPTION
This is currently broken on centos8 images.

[noissue]

They really should not be needed for the tests anyway. And if we really need them often they should be part of the CI image. If only occasionally, the individual plugin pre_before_script is the right place.