### PR TITLE
Calculate lowerbounds as constraints

### DIFF
--- a/templates/github/.ci/scripts/calc_deps_lowerbounds.py.j2
+++ b/templates/github/.ci/scripts/calc_deps_lowerbounds.py.j2
@@ -4,13 +4,18 @@ from packaging.requirements import Requirement
 
 
 def main():
-    """Calculate the lower bound of dependencies where possible."""
+    """Calculate constraints for the lower bound of dependencies where possible."""
     with open("requirements.txt") as req_file:
         for line in req_file:
+            split_line = line.split("#", maxsplit=1)
             try:
-                requirement = Requirement(line)
+                comment = "  # " + split_line[1].strip()
+            except IndexError:
+                comment = ""
+            try:
+                requirement = Requirement(split_line[0])
             except ValueError:
-                print(line.strip())
+                print(f"# {line.strip()}")
             else:
                 for spec in requirement.specifier:
                     if spec.operator == ">=":
@@ -19,10 +24,10 @@ def main():
                         else:
                             operator = "=="
                         min_version = str(spec)[2:]
-                        print(f"{requirement.name}{operator}{min_version}")
+                        print(f"{requirement.name}{operator}{min_version}{comment}")
                         break
                 else:
-                    print(line.strip())
+                    print(f"# {line.strip()}")
 
 
 if __name__ == "__main__":

--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -62,7 +62,6 @@ fi
 
 if [[ "$TEST" = "lowerbounds" ]]; then
   python3 .ci/scripts/calc_deps_lowerbounds.py > lowerbounds_constraints.txt
-  sed -i 's/\[.*\]//g' lowerbounds_constraints.txt
 fi
 
 if [ -f $POST_BEFORE_INSTALL ]; then


### PR DESCRIPTION
The script was originally creating a replacement for requirements, but is now used as constraints. Postprocessing should not be necessary.