### PR TITLE
Fix bindings setup error in performance test

### DIFF
--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -88,6 +88,28 @@ jobs:
           name: "plugin_package"
           path: "{{ plugin_name }}/dist/"
 
+      - name: "Download API specs"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "api_spec"
+          path: "{{ plugin_name }}/"
+
+      - name: "Download client packages"
+        uses: "actions/download-artifact@v4"
+        with:
+          name: "python-client.tar"
+          path: "{{ plugin_name }}"
+
+      - name: "Unpack client packages"
+        working-directory: "pulp-openapi-generator"
+        run: |
+          {%- for plugin in plugins %}
+          mkdir -p "{{ plugin.name | snake }}-client"
+          pushd "{{ plugin.name | snake }}-client"
+          tar xvf "../../{{ plugin_name }}/{{ plugin.app_label }}-python-client.tar"
+          popd
+          {%- endfor %}
+
       {{ setup_python() | indent(6) }}
 
       {{ setup_env(test="performance") | indent(6) }}


### PR DESCRIPTION
Reported in RPM: https://github.com/pulp/pulp_rpm/actions/runs/9933072491/job/27458080556#step:11:2222

## Problem

When running the performance tests in the nighly.yml workflow, the bindings generation section would fail with missing client dir and rpm-api.json file.

## Approach

This PR adds steps to the performance test job to download such missing artifacts.
The steps where copied over from the [test.yml](https://github.com/pulp/plugin_template/blob/88e2a0029ecdd700516e4361cf213020e25ecfdd/templates/github/.github/workflows/test.yml.j2#L57-L77), which also uses the `script.sh`.

Test Nighly Run (on my fork) which incorporate those changes:
https://github.com/pedro-psb/pulp_rpm/actions/runs/9962429240/job/27526211393