### PR TITLE
Fix constraints calculation

### DIFF
--- a/templates/github/.ci/scripts/calc_constraints.py.j2
+++ b/templates/github/.ci/scripts/calc_constraints.py.j2
@@ -58,7 +58,7 @@ def to_upper_bound(req):
                 elif version.minor != 0:
                     max_version = f"{version.major}.{version.minor-1}"
                 elif version.major != 0:
-                    max_version = f"{version.major-1}"
+                    max_version = f"{version.major-1}.0"
                 else:
                     return f"# NO BETTER CONSTRAINT: {req}"
                 return f"{requirement.name}{operator}{max_version}"


### PR DESCRIPTION
'~=4' is not a valid specifier, however '~=4.0' is.