### PR TITLE
Fix update_core_lowerbound for more than x.y

### DIFF
--- a/scripts/update_core_lowerbound.py
+++ b/scripts/update_core_lowerbound.py
@@ -29,7 +29,7 @@ def main():
                         for spec in requirement.specifier:
                             if spec.operator == ">=":
                                 min_version = parse(spec.version)
-                                if min_version not in versions:
+                                if parse(f"{min_version.major}.{min_version.minor}") not in versions:
                                     # Lowerbound is not a supported branch, modify to next lowest
                                     valid_lowerbounds = list(requirement.specifier.filter(versions))
                                     if valid_lowerbounds:


### PR DESCRIPTION
A requirement of pulpcore>=x.y.z was not properly recognized by the script.