### PR TITLE
Add requests to installed dependencies for create-branch

### DIFF
--- a/templates/github/.github/workflows/create-branch.yml.j2
+++ b/templates/github/.github/workflows/create-branch.yml.j2
@@ -25,7 +25,7 @@ jobs:
 
       {{ setup_python() | indent(6) }}
 
-      {{ install_python_deps(["bump2version", "jinja2", "pyyaml", "packaging"]) | indent(6) }}
+      {{ install_python_deps(["bump2version", "jinja2", "pyyaml", "packaging", "requests"]) | indent(6) }}
 
       {{ set_secrets(path=plugin_name) | indent(6) }}
 


### PR DESCRIPTION
We might want to look into having the requirements.txt file contain all the needed requirements to run the templater because I think it's missing a few. This is a quick fix to get the new y releases working again.