### PR TITLE
Make pytest timeout configurable and with higher defaults

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -58,6 +58,7 @@ DEFAULT_SETTINGS = {
     "pulp_settings": None,
     "pulp_settings_s3": None,
     "pydocstyle": True,
+    "pytest_timeout": 3600,
     "release_email": "pulp-infra@redhat.com",
     "release_user": "pulpbot",
     "stalebot_days_until_close": 30,

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -135,13 +135,13 @@ else
   if [[ "$GITHUB_WORKFLOW" =~ "Nightly" ]]
   then
     {%- for plugin in plugins %}
-    cmd_user_prefix bash -c "pytest -v --timeout=300 -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin.name | snake }}.tests.functional -m parallel -n {{ parallel_test_workers }} --nightly"
-    cmd_user_prefix bash -c "pytest -v --timeout=300 -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin.name | snake }}.tests.functional -m 'not parallel' --nightly"
+    cmd_user_prefix bash -c "pytest -v --timeout={{ pytest_timeout }} -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin.name | snake }}.tests.functional -m parallel -n {{ parallel_test_workers }} --nightly"
+    cmd_user_prefix bash -c "pytest -v --timeout={{ pytest_timeout }} -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin.name | snake }}.tests.functional -m 'not parallel' --nightly"
     {%- endfor %}
   else
     {%- for plugin in plugins %}
-    cmd_user_prefix bash -c "pytest -v --timeout=300 -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin.name | snake }}.tests.functional -m parallel -n {{ parallel_test_workers }}"
-    cmd_user_prefix bash -c "pytest -v --timeout=300 -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin.name | snake }}.tests.functional -m 'not parallel'"
+    cmd_user_prefix bash -c "pytest -v --timeout={{ pytest_timeout }} -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin.name | snake }}.tests.functional -m parallel -n {{ parallel_test_workers }}"
+    cmd_user_prefix bash -c "pytest -v --timeout={{ pytest_timeout }} -r sx --color=yes --suppress-no-test-exit-code --pyargs {{ plugin.name | snake }}.tests.functional -m 'not parallel'"
     {%- endfor %}
   fi
 fi


### PR DESCRIPTION
As stated [here](https://github.com/pulp/plugin_template/commit/ece49c9e91e49490ba83507341b801e4ded581da), the timeout is meant to catch unexpected hanging tasks and have to meaningful stacktrace.

Then, it is not so important to minimize the timeout as it is to prevent long testing from failing unexpectedly, so I think we can raise the bar here.

01h sounds safe in general?

## Context

[This rpm test](https://github.com/pulp/pulp_rpm/actions/runs/10812774961/job/29995301298#step:15:3912) was failing due to the timeout and took me some time to realize this was this pytest-timeout plugin. On my machine it ran in 38m.