### PR TITLE
Reorder pip install to better prioritize

### DIFF
--- a/.ci/scripts/pr_labels.py
+++ b/.ci/scripts/pr_labels.py
@@ -18,9 +18,12 @@ def main():
     BLOCKING_REGEX = re.compile(r"DRAFT|WIP|NO\s*MERGE|DO\s*NOT\s*MERGE|EXPERIMENT")
     ISSUE_REGEX = re.compile(r"(?:fixes|closes)[\s:]+#(\d+)")
     CHERRY_PICK_REGEX = re.compile(r"^\s*\(cherry picked from commit [0-9a-f]*\)\s*$")
-    CHANGELOG_EXTS = [
-        f".{item['directory']}" for item in PYPROJECT_TOML["tool"]["towncrier"]["type"]
-    ]
+    try:
+        CHANGELOG_EXTS = {
+            f".{item['directory']}" for item in PYPROJECT_TOML["tool"]["towncrier"]["type"]
+        }
+    except KeyError:
+        CHANGELOG_EXTS = {"feature", "bugfix", "doc", "removal", "misc"}
 
     repo = Repo(".")
 

--- a/templates/github/.ci/ansible/Containerfile.j2.copy
+++ b/templates/github/.ci/ansible/Containerfile.j2.copy
@@ -12,7 +12,7 @@ ADD ./{{ item.name }} ./{{ item.name }}
 # This MUST be the ONLY call to pip install in inside the container.
 RUN pip3 install --upgrade pip setuptools wheel && \
   rm -rf /root/.cache/pip && \
-  pip3 install pipdeptree
+  pip3 install
 {%- if s3_test | default(false) -%}
 {{ " " }}git+https://github.com/gerrod3/botocore.git@fix-100-continue
 {%- endif -%}
@@ -28,7 +28,8 @@ RUN pip3 install --upgrade pip setuptools wheel && \
 {{ " " }}-r ./{{ item.name }}/ci_requirements.txt
 {%- endif -%}
 {%- endfor %}
-{{ " " }}-c ./{{ plugins[0].name }}/.ci/assets/ci_constraints.txt && \
+{{ " " }}-c ./{{ plugins[0].name }}/.ci/assets/ci_constraints.txt \
+  pipdeptree && \
   rm -rf /root/.cache/pip
 
 {% if pulp_env is defined and pulp_env %}

--- a/templates/github/.ci/assets/ci_constraints.txt
+++ b/templates/github/.ci/assets/ci_constraints.txt
@@ -5,3 +5,8 @@ pulpcore>=3.21.30,!=3.23.*,!=3.24.*,!=3.25.*,!=3.26.*,!=3.27.*,!=3.29.*,!=3.30.*
 
 tablib!=3.6.0
 # 3.6.0: This release introduced a regression removing the "html" optional dependency.
+
+
+
+# Newer version seem to have a conflict around packaging, that pip fails to resolve in time. Remove this when this starts to impose an issue.
+pipdeptree<=3.23.1

--- a/templates/github/.ci/scripts/pr_labels.py
+++ b/templates/github/.ci/scripts/pr_labels.py
@@ -18,9 +18,12 @@ def main():
     BLOCKING_REGEX = re.compile(r"DRAFT|WIP|NO\s*MERGE|DO\s*NOT\s*MERGE|EXPERIMENT")
     ISSUE_REGEX = re.compile(r"(?:fixes|closes)[\s:]+#(\d+)")
     CHERRY_PICK_REGEX = re.compile(r"^\s*\(cherry picked from commit [0-9a-f]*\)\s*$")
-    CHANGELOG_EXTS = [
-        f".{item['directory']}" for item in PYPROJECT_TOML["tool"]["towncrier"]["type"]
-    ]
+    try:
+        CHANGELOG_EXTS = {
+            f".{item['directory']}" for item in PYPROJECT_TOML["tool"]["towncrier"]["type"]
+        }
+    except KeyError:
+        CHANGELOG_EXTS = {"feature", "bugfix", "doc", "removal", "misc"}
 
     repo = Repo(".")
 


### PR DESCRIPTION
pipdeptree as a debugging tool should really go last.