### PR TITLE
Only use published/prebuilt bindings in the 'pulp' test scenario

### DIFF
--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -41,12 +41,14 @@ pushd ../pulp-openapi-generator
 
   # Workaround: Domains are not supported by the published bindings.
   # Sadly: Different pulpcore-versions aren't either...
-  # So we exclude the prebuilt ones only for domains disabled.
-  if [ "$(jq -r '.domain_enabled' <<<"${REPORTED_STATUS}")" = "true" ] || [ "$(jq -r '.online_workers[0].pulp_href|startswith("/pulp/api/v3/")' <<< "${REPORTED_STATUS}")" = "false" ]
+  # * In the 'pulp' scenario we use the published/prebuilt bindings, so we can test it.
+  # * In other scenarios we generate new bindings from server spec, so we have a more
+  #   reliable client.
+  if [ "$TEST" = "pulp" ]
   then
-    BUILT_CLIENTS=""
-  else
     BUILT_CLIENTS="{% for plugin in plugins %} {{ plugin.app_label }}{% endfor %} "
+  else
+    BUILT_CLIENTS=""
   fi
 
   for ITEM in $(jq -r '.versions[] | tojson' <<<"${REPORTED_STATUS}")


### PR DESCRIPTION
This is to prevent using clients built from different pulpcore versions than those installed in the app we want to test.

Closes #917