### PR TITLE
Remove pipdeptree

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,5 +156,5 @@ jobs:
           docker logs pulp || true
           docker exec pulp ls -latr /etc/yum.repos.d/ || true
           docker exec pulp cat /etc/yum.repos.d/* || true
-          docker exec pulp bash -c "pip3 list && pip3 install pipdeptree && pipdeptree"
+          docker exec pulp bash -c "pip3 list" || true
 ...

--- a/templates/github/.ci/ansible/Containerfile.j2.copy
+++ b/templates/github/.ci/ansible/Containerfile.j2.copy
@@ -28,8 +28,7 @@ RUN pip3 install --upgrade pip setuptools wheel && \
 {{ " " }}-r ./{{ item.name }}/ci_requirements.txt
 {%- endif -%}
 {%- endfor %}
-{{ " " }}-c ./{{ plugins[0].name }}/.ci/assets/ci_constraints.txt \
-  pipdeptree && \
+{{ " " }}-c ./{{ plugins[0].name }}/.ci/assets/ci_constraints.txt && \
   rm -rf /root/.cache/pip
 
 {% if pulp_env is defined and pulp_env %}

--- a/templates/github/.ci/assets/ci_constraints.txt
+++ b/templates/github/.ci/assets/ci_constraints.txt
@@ -5,8 +5,3 @@ pulpcore>=3.21.30,!=3.23.*,!=3.24.*,!=3.25.*,!=3.26.*,!=3.27.*,!=3.29.*,!=3.30.*
 
 tablib!=3.6.0
 # 3.6.0: This release introduced a regression removing the "html" optional dependency.
-
-
-
-# Newer version seem to have a conflict around packaging, that pip fails to resolve in time. Remove this when this starts to impose an issue.
-pipdeptree<=3.23.1

--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -221,5 +221,5 @@ if [[ "$TEST" = "azure" ]]; then
 fi
 
 echo ::group::PIP_LIST
-cmd_prefix bash -c "pip3 list && pipdeptree"
+cmd_prefix bash -c "pip3 list"
 echo ::endgroup::

--- a/templates/macros.j2
+++ b/templates/macros.j2
@@ -86,7 +86,7 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
     docker logs pulp || true
     docker exec pulp ls -latr /etc/yum.repos.d/ || true
     docker exec pulp cat /etc/yum.repos.d/* || true
-    docker exec pulp bash -c "pip3 list && pip3 install pipdeptree && pipdeptree"
+    docker exec pulp bash -c "pip3 list" || true
 {%- endmacro -%}
 
 


### PR DESCRIPTION
Pip deptree has dependencies on it's own and they collide with pulp dependencies at points. So whenever this tool is supposed to help, we cannot even trust it, or it prevents the installation in the first place.