### PR TITLE
Fix ready-to-ship depend on docs

### DIFF
--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -88,7 +88,9 @@ jobs:
       {%- endif %}
       - "lint"
       - "test"
+      {%- if is_pulpdocs_member %}
       - "docs"
+      {%- endif %}
     if: "always()"
     steps:
       - name: "Collect needed jobs results"


### PR DESCRIPTION
In case there is no "docs" step in the CI, we should not depend on it.