### PR TITLE
Use wildcards in publishing to avoid -_ conflicts

### DIFF
--- a/templates/github/.github/workflows/scripts/publish_plugin_pypi.sh.j2
+++ b/templates/github/.github/workflows/scripts/publish_plugin_pypi.sh.j2
@@ -23,6 +23,6 @@ then
 fi
 
 twine upload -u __token__ -p "$PYPI_API_TOKEN" \
-"dist/{{ plugin_name | snake }}-$VERSION-py3-none-any.whl" \
-"dist/{{ plugin_name | dash }}-$VERSION.tar.gz" \
+dist/{{ plugin_name | snake | replace("_", "?") }}-"$VERSION"-py3-none-any.whl \
+dist/{{ plugin_name | snake | replace("_", "?") }}-"$VERSION".tar.gz \
 ;


### PR DESCRIPTION
Somehow in the python ecosystem you can never know when filenames or directory names should be "-" or "_". By giving a "?" to the shell, we should be rather safe.