### PR TITLE
Partially revert "Remove old CI migration code"

### DIFF
--- a/templates/github/.ci/scripts/check_requirements.py.j2
+++ b/templates/github/.ci/scripts/check_requirements.py.j2
@@ -57,7 +57,10 @@ def main():
                 else:
                     if check_prereleases and req.specifier.prereleases:
                         # Do not even think about begging for more exceptions!
-                        if req.name != "{{ plugin_name | dash }}-client":
+                        if (
+                            not req.name.startswith("opentelemetry")
+                            and req.name != "{{ plugin_name | dash }}-client"
+                        ):
                             errors.append(f"{filename}:{nr}: Prerelease versions found in {line}.")
                     ops = [spec.operator for spec in req.specifier]
                     if "~=" in ops:


### PR DESCRIPTION
We forgot to think about old branches, which we still need to accommodate for.

This reverts commit 2b875a20dabaf51d886e8197cf174f83d2a05bd8.