### PR TITLE
Secure pr_check workflow

### DIFF
--- a/templates/github/.github/workflows/pr_checks.yml.j2
+++ b/templates/github/.github/workflows/pr_checks.yml.j2
@@ -7,7 +7,13 @@ with context %}
 name: "{{ plugin_app_label | camel }} PR static checks"
 on:
   pull_request_target:
-    types: ["opened", "synchronize", "reopened"]
+    types:
+      - "opened"
+      - "synchronize"
+      - "reopened"
+    branches:
+      - "{{ default_branch }}"
+      - "[0-9]+.[0-9]+"
 
 # This workflow runs with elevated permissions.
 # Do not even think about running a single bit of code from the PR.


### PR DESCRIPTION
Make sure the PR-target is only run against sanctioned base branches.