### PR TITLE
[PULP-227] Remove preupload check from release workflow

### DIFF
--- a/templates/github/.github/workflows/scripts/publish_client_gem.sh.j2
+++ b/templates/github/.github/workflows/scripts/publish_client_gem.sh.j2
@@ -9,23 +9,16 @@ cd "$(dirname "$(realpath -e "$0")")"/../../..
 
 VERSION="$1"
 
-if [[ -z "$VERSION" ]]; then
+if [[ -z "${VERSION}" ]]
+then
   echo "No version specified."
   exit 1
-fi
-
-RESPONSE="$(curl --write-out '%{http_code}' --silent --output /dev/null "https://rubygems.org/gems/{{ plugin_name | snake }}_client/versions/$VERSION")"
-
-if [ "$RESPONSE" == "200" ];
-then
-  echo "{{ plugin_name }} client $VERSION has already been released. Skipping."
-  exit
 fi
 
 mkdir -p ~/.gem
 touch ~/.gem/credentials
 echo "---
-:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
+:rubygems_api_key: ${RUBYGEMS_API_KEY}" > ~/.gem/credentials
 sudo chmod 600 ~/.gem/credentials
 
 {%- for plugin in plugins %}

--- a/templates/github/.github/workflows/scripts/publish_client_pypi.sh.j2
+++ b/templates/github/.github/workflows/scripts/publish_client_pypi.sh.j2
@@ -9,20 +9,15 @@ cd "$(dirname "$(realpath -e "$0")")/../../.."
 
 VERSION="$1"
 
-if [[ -z "$VERSION" ]]; then
+if [[ -z "${VERSION}" ]]
+then
   echo "No version specified."
   exit 1
 fi
+
+twine upload -u __token__ -p "${PYPI_API_TOKEN}" \
 {%- for plugin in plugins %}
-
-RESPONSE="$(curl --write-out '%{http_code}' --silent --output /dev/null "https://pypi.org/project/{{ plugin.name | dash }}-client/$VERSION/")"
-
-if [ "$RESPONSE" == "200" ];
-then
-  echo "{{ plugin.name }} client $VERSION has already been released. Skipping."
-else
-  twine upload -u __token__ -p "$PYPI_API_TOKEN" \
-  "dist/{{ plugin.name | snake }}_client-$VERSION-py3-none-any.whl" \
-  "dist/{{ plugin.name | snake }}-client-$VERSION.tar.gz"
-fi
+"dist/{{ plugin.name | snake }}_client-${VERSION}-py3-none-any.whl" \
+"dist/{{ plugin.name | snake }}-client-${VERSION}.tar.gz" \
 {%- endfor %}
+;

--- a/templates/github/.github/workflows/scripts/publish_plugin_pypi.sh.j2
+++ b/templates/github/.github/workflows/scripts/publish_plugin_pypi.sh.j2
@@ -9,20 +9,13 @@ cd "$(dirname "$(realpath -e "$0")")"/../../..
 
 VERSION="$1"
 
-if [[ -z "$VERSION" ]]; then
+if [[ -z "${VERSION}" ]]
+then
   echo "No version specified."
   exit 1
 fi
 
-RESPONSE="$(curl --write-out '%{http_code}' --silent --output /dev/null "https://pypi.org/project/{{ plugin_name | dash }}/$VERSION/")"
-
-if [ "$RESPONSE" == "200" ];
-then
-  echo "{{ plugin_name }} $VERSION has already been released. Skipping."
-  exit
-fi
-
-twine upload -u __token__ -p "$PYPI_API_TOKEN" \
-dist/{{ plugin_name | snake | replace("_", "?") }}-"$VERSION"-py3-none-any.whl \
-dist/{{ plugin_name | snake | replace("_", "?") }}-"$VERSION".tar.gz \
+twine upload -u __token__ -p "${PYPI_API_TOKEN}" \
+"dist/{{ plugin_name | snake | replace("_", "?") }}-${VERSION}-py3-none-any.whl" \
+"dist/{{ plugin_name | snake | replace("_", "?") }}-${VERSION}.tar.gz" \
 ;


### PR DESCRIPTION
This check is broken and prevents any further releases to be published to PyPi. But also it outlived it's purpose. In the current state of the release process it would actually be better to let the workflow job rightfully fail.