### PR TITLE
Add flag to exercise django's STORAGES setting on CI

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -72,6 +72,7 @@ DEFAULT_SETTINGS = {
     "test_performance": False,
     "test_reroute": True,
     "test_s3": False,
+    "test_storages_compat_layer": False,
     "use_issue_template": True,
 }
 

--- a/templates/github/.ci/ansible/settings.py.j2.copy
+++ b/templates/github/.ci/ansible/settings.py.j2.copy
@@ -22,17 +22,32 @@ API_ROOT = {{ api_root | repr }}
 
 {% if pulp_scenario_settings is defined and pulp_scenario_settings %}
 {% for key, value in pulp_scenario_settings.items() %}
-{% if not (s3_test | default(false) and key == "STORAGES") %}
 {{ key | upper }} = {{ value | repr }}
-{% endif %}
 {% endfor %}
 {% endif %}
 
 {% if s3_test | default(false) %}
 MEDIA_ROOT: ""
 S3_USE_SIGV4 = True
-{% if "STORAGES" in pulp_scenario_settings %}
-STORAGES = {{ pulp_scenario_settings["STORAGES"] }}
+{% if test_storages_compat_layer %}
+STORAGES = {
+    "default": {
+        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+        "OPTIONS": {
+            "access_key": "{{ minio_access_key }}",
+            "secret_key": "{{ minio_secret_key }}",
+            "region_name": "eu-central-1",
+            "addressing_style": "path",
+            "signature_version": "s3v4",
+            "bucket_name": "pulp3",
+            "endpoint_url": "http://minio:9000",
+            "default_acl": "@none None",
+        },
+    },
+    "staticfiles": {
+      "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
 {% else %}
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_ACCESS_KEY_ID = "{{ minio_access_key }}"

--- a/templates/github/.ci/ansible/settings.py.j2.copy
+++ b/templates/github/.ci/ansible/settings.py.j2.copy
@@ -22,22 +22,28 @@ API_ROOT = {{ api_root | repr }}
 
 {% if pulp_scenario_settings is defined and pulp_scenario_settings %}
 {% for key, value in pulp_scenario_settings.items() %}
+{% if not (s3_test | default(false) and key == "STORAGES") %}
 {{ key | upper }} = {{ value | repr }}
+{% endif %}
 {% endfor %}
 {% endif %}
 
 {% if s3_test | default(false) %}
+MEDIA_ROOT: ""
+S3_USE_SIGV4 = True
+{% if "STORAGES" in pulp_scenario_settings %}
+STORAGES = {{ pulp_scenario_settings["STORAGES"] }}
+{% else %}
 DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-MEDIA_ROOT = ""
 AWS_ACCESS_KEY_ID = "{{ minio_access_key }}"
 AWS_SECRET_ACCESS_KEY = "{{ minio_secret_key }}"
 AWS_S3_REGION_NAME = "eu-central-1"
 AWS_S3_ADDRESSING_STYLE = "path"
-S3_USE_SIGV4 = True
 AWS_S3_SIGNATURE_VERSION = "s3v4"
 AWS_STORAGE_BUCKET_NAME = "pulp3"
 AWS_S3_ENDPOINT_URL = "http://minio:9000"
 AWS_DEFAULT_ACL = "@none None"
+{% endif %}
 {% endif %}
 
 {% if azure_test | default(false) %}

--- a/templates/github/.ci/ansible/settings.py.j2.copy
+++ b/templates/github/.ci/ansible/settings.py.j2.copy
@@ -29,7 +29,7 @@ API_ROOT = {{ api_root | repr }}
 {% if s3_test | default(false) %}
 MEDIA_ROOT: ""
 S3_USE_SIGV4 = True
-{% if test_storages_compat_layer %}
+{% if test_storages_compat_layer is defined and test_storages_compat_layer %}
 STORAGES = {
     "default": {
         "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",

--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -126,6 +126,7 @@ minio_access_key: "'$MINIO_ACCESS_KEY'"\
 minio_secret_key: "'$MINIO_SECRET_KEY'"\
 pulp_scenario_settings: {{ pulp_settings_s3 | tojson }}\
 pulp_scenario_env: {{ pulp_env_s3 | tojson }}\
+test_storages_compat_layer: {{ test_storages_compat_layer | tojson }}\
 ' vars/main.yaml
 
   {%- if test_reroute %}


### PR DESCRIPTION
If plugins provide STORAGES in the s3 settings in the template config, these will be used intead of the default ones from the template.