### PR TITLE
Add pycares!=4.9.0 to ci_constraints.txt

### DIFF
--- a/templates/github/.ci/assets/ci_constraints.txt
+++ b/templates/github/.ci/assets/ci_constraints.txt
@@ -8,3 +8,8 @@ tablib!=3.6.0
 
 multidict!=6.3.0
 # This release failed the lower bounds test for some case sensitivity in CIMultiDict.
+
+
+pycares!=4.9.0
+# This release introduced a regression which may cause pytest runs to hang indefinitely.
+# https://github.com/saghul/pycares/releases/tag/v4.9.0


### PR DESCRIPTION
This version introduced a regression where pytest runs hangs forever.