### PR TITLE
automatically run black on files we update via templates

### DIFF
--- a/plugin-template
+++ b/plugin-template
@@ -426,6 +426,10 @@ def generate_relative_path_set(root_dir):
             template_abs_path = os.path.join(root, file_name)
             template_relative_path = os.path.relpath(template_abs_path, root_dir)
             applicable_paths.add(template_relative_path)
+    applicable_paths = list(applicable_paths)
+    if "pyproject.toml.j2" in applicable_paths:
+        applicable_paths.remove("pyproject.toml.j2")
+        applicable_paths.insert(0, "pyproject.toml.j2")
     return applicable_paths
 
 

--- a/plugin-template
+++ b/plugin-template
@@ -5,6 +5,7 @@ import os
 import pprint
 import shlex
 import shutil
+import subprocess
 import sys
 import textwrap
 from pathlib import Path
@@ -402,6 +403,14 @@ def write_template_section(config, name, plugin_root_dir, verbose=False):
             files_copied += 1
             if verbose:
                 print(f"Copied file: {relative_path}")
+        if config["black"] and destination_relative_path.endswith((".py", ".py.j2")):
+            if destination_relative_path.endswith(".py.j2"):
+                destination = destination_relative_path[: -len(".j2")]
+            else:
+                destination = destination_relative_path
+
+            if os.path.exists(os.path.join(plugin_root_dir, destination)):
+                subprocess.run(["black", "--quiet", destination], cwd=plugin_root_dir)
 
     print(f"Section: {name} \n    templated: {files_templated}\n    copied: {files_copied}")
     return 0

--- a/plugin-template
+++ b/plugin-template
@@ -358,7 +358,8 @@ def write_template_section(config, name, plugin_root_dir, verbose=False):
         **config,
     }
 
-    for relative_path in generate_relative_path_set(section_template_dir):
+    relative_path_set = generate_relative_path_set(section_template_dir)
+    for relative_path in relative_path_set:
         if not config["stalebot"] and "stale" in relative_path:
             continue
         if config["use_issue_template"] is False and "ISSUE_TEMPLATE" in relative_path:
@@ -403,14 +404,17 @@ def write_template_section(config, name, plugin_root_dir, verbose=False):
             files_copied += 1
             if verbose:
                 print(f"Copied file: {relative_path}")
-        if config["black"] and destination_relative_path.endswith((".py", ".py.j2")):
-            if destination_relative_path.endswith(".py.j2"):
-                destination = destination_relative_path[: -len(".j2")]
-            else:
-                destination = destination_relative_path
 
-            if os.path.exists(os.path.join(plugin_root_dir, destination)):
-                subprocess.run(["black", "--quiet", destination], cwd=plugin_root_dir)
+    if config["black"]:
+        black_paths = filter(lambda x: x.endswith(".py.j2"), relative_path_set)
+        black_paths = map(lambda x: x[: -len(".j2")], black_paths)
+        black_paths = map(
+            lambda x: x.replace("plugin_name", utils.to_snake(config["plugin_name"])), black_paths
+        )
+        black_paths = filter(
+            lambda x: os.path.exists(os.path.join(plugin_root_dir, x)), black_paths
+        )
+        subprocess.run(["black", "--quiet"] + list(black_paths), cwd=plugin_root_dir)
 
     print(f"Section: {name} \n    templated: {files_templated}\n    copied: {files_copied}")
     return 0
@@ -426,10 +430,6 @@ def generate_relative_path_set(root_dir):
             template_abs_path = os.path.join(root, file_name)
             template_relative_path = os.path.relpath(template_abs_path, root_dir)
             applicable_paths.add(template_relative_path)
-    applicable_paths = list(applicable_paths)
-    if "pyproject.toml.j2" in applicable_paths:
-        applicable_paths.remove("pyproject.toml.j2")
-        applicable_paths.insert(0, "pyproject.toml.j2")
     return applicable_paths
 
 


### PR DESCRIPTION
sometimes filling in a template leads to black changes (when an URL makes a line too long, for example), so lets fix that directly when generating, avoiding a second "black" commit