### PR TITLE
Revert "Add pycares!=4.9.0 to ci_constraints.txt"

### DIFF
--- a/templates/github/.ci/assets/ci_constraints.txt
+++ b/templates/github/.ci/assets/ci_constraints.txt
@@ -8,8 +8,3 @@ tablib!=3.6.0
 
 multidict!=6.3.0
 # This release failed the lower bounds test for some case sensitivity in CIMultiDict.
-
-
-pycares!=4.9.0
-# This release introduced a regression which may cause pytest runs to hang indefinitely.
-# https://github.com/saghul/pycares/releases/tag/v4.9.0


### PR DESCRIPTION
Reverts pulp/plugin_template#962

It turned out to be more than just a single bad release of pycares. Instead, we need to carefully adjust the aiodns version range on individual release branches.