### PR TITLE
[PULP-654] Skip scoped requirements on upperbound calculation

### DIFF
--- a/templates/github/.ci/scripts/calc_constraints.py.j2
+++ b/templates/github/.ci/scripts/calc_constraints.py.j2
@@ -48,6 +48,9 @@ def to_upper_bound(req):
         if requirement.name == "pulpcore":
             # An exception to allow for pulpcore deprecation policy.
             return fetch_pulpcore_upper_bound(requirement)
+        # skip requirement with environment scopes. E.g 'foo==1.0.0;python_version>=3.9'
+        if requirement.marker:
+            return f"# ENVIRONMENT IS UNTRACKABLE: {req}"
         for spec in requirement.specifier:
             if spec.operator == "~=":
                 return f"# NO BETTER CONSTRAINT: {req}"


### PR DESCRIPTION
The script does not know about the environment (os, python version, ...).