### PR TITLE
Use towncrier to generate Github release notes

### DIFF
--- a/templates/github/.github/workflows/publish.yml.j2
+++ b/templates/github/.github/workflows/publish.yml.j2
@@ -142,11 +142,28 @@ jobs:
     permissions:
       contents: write
 
+    env:
+      TAG_NAME: "{{ '${{ github.ref_name }}' }}"
+
     steps:
+      {{ checkout(depth=0, path=plugin_name) | indent(6) }}
+
+      {{ setup_python(pyversion="3.11") | indent(6) }}
+
+      - name: "Install towncrier"
+        run: |
+          pip install towncrier
+
+      - name: "Get release notes"
+        id: get_release_notes
+        run: |
+          NOTES=$(towncrier build --draft --version $TAG_NAME)
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          echo "$NOTES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: "Create release on GitHub"
         uses: "actions/github-script@v7"
-        env:
-          TAG_NAME: "{{ '${{ github.ref_name }}' }}"
         with:
           script: |
             const { TAG_NAME } = process.env;
@@ -155,5 +172,6 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: TAG_NAME,
+              body: `{% raw %}${{ steps.get_release_notes.outputs.body }}{% endraw %}`,
               make_latest: "legacy",
             });


### PR DESCRIPTION
This change modifies the GitHub Actions workflow to use towncrier
to generate release notes from changelog fragments and add them to
the GitHub release body.

Assisted-by: gemini-2.5-pro
