### PR TITLE
Fix the changes gathering for the gh-release job

### DIFF
--- a/templates/github/.github/workflows/publish.yml.j2
+++ b/templates/github/.github/workflows/publish.yml.j2
@@ -155,8 +155,11 @@ jobs:
           pip install towncrier
 
       - name: "Get release notes"
-        id: get_release_notes
+        id: "get_release_notes"
+        shell: "bash"
         run: |
+          # The last commit before the release commit contains the release CHANGES fragments
+          git checkout "${TAG_NAME}~"
           NOTES=$(towncrier build --draft --version $TAG_NAME)
           echo "body<<EOF" >> $GITHUB_OUTPUT
           echo "$NOTES" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Towncrier was being called on a commit after the release commit, but the towncrier fragments are consumed when a relase commit is created on the release workflow.

The fix proposal is to checkout the last commit before the release commit, where the fragments are still available.