### PR TITLE
Cleanup the workaround for skipping docs on nondefault branches

### DIFF
--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_tests: {{ '${{ steps.check.outputs.run_tests }}' }}
+      run_docs: {{ '${{ steps.check.outputs.run_docs }}' }}
     steps:
       {{ checkout(depth=0, path=plugin_name) | indent(6) }}
 
@@ -54,6 +55,13 @@ jobs:
         shell: bash
         id: check
         run: |
+          # We only test docs on the default branch (usually main)
+          if [[ "{{ '${{ github.base_ref }}' }}" == *"{{ plugin_default_branch }}" ]]; then
+            echo "run_docs=1" >> $GITHUB_OUTPUT
+          else
+            echo "run_docs=0" >> $GITHUB_OUTPUT
+          fi
+
           set +e
           BASE_REF={{ "${{ github.event.pull_request.base.sha }}" }}
           echo "Checking against:"
@@ -69,7 +77,10 @@ jobs:
   {%- if is_pulpdocs_member %}
 
   docs:
+    needs: "check-changes"
     uses: "./.github/workflows/docs.yml"
+    with:
+      run_docs: {{ '${{ needs.check-changes.outputs.run_docs }}' }}
   {%- endif %}
 
   lint:
@@ -132,15 +143,32 @@ jobs:
       - name: "Collect needed jobs results"
         working-directory: "."
         run: |
-          if [ {{ "${{ needs.check-changes.outputs.run_tests }}" }} == "1" ]; then
-            # Full test run - check all jobs
-            echo {{ "'${{toJson(needs)}}'" }} | jq -r 'to_entries[]|select(.value.result!="success")|.key + ": " + .value.result'
-            echo {{ "'${{toJson(needs)}}'" }} | jq -e 'to_entries|map(select(.value.result!="success"))|length == 0'
-          else
-            # Docs-only run - check only required jobs (exclude lint and test)
-            echo {{ "'${{toJson(needs)}}'" }} | jq -r 'to_entries[]|select(.key != "lint" and .key != "test")|select(.value.result!="success")|.key + ": " + .value.result'
-            echo {{ "'${{toJson(needs)}}'" }} | jq -e 'to_entries|map(select(.key != "lint" and .key != "test"))|map(select(.value.result!="success"))|length == 0'
+          RUN_TESTS={{ "${{ needs.check-changes.outputs.run_tests }}" }}
+          RUN_DOCS={{ "${{ needs.check-changes.outputs.run_docs }}" }}
+
+          check_jobs() {
+            local filter="$1"
+            local needs_json={{ "'${{toJson(needs)}}'" }}
+            # output failed jobs after filter
+            echo "$needs_json" | jq -r "to_entries[]|select($filter)|select(.value.result!=\"success\")|.key + \": \" + .value.result"
+            # fails if not all selected jobs passed
+            echo "$needs_json" | jq -e "to_entries|map(select($filter))|map(select(.value.result!=\"success\"))|length == 0"
+          }
+
+          if [ "$RUN_TESTS" == "1" ] && [ "$RUN_DOCS" == "1" ]; then
+            FILTERS="true"  # check all jobs
+          elif [ "$RUN_TESTS" == "1" ] && [ "$RUN_DOCS" == "0" ]; then
+            echo "Skipping docs: running on non-default branch"
+            FILTERS='.key != "docs"'
+          elif [ "$RUN_TESTS" == "0" ] && [ "$RUN_DOCS" == "1" ]; then
+            echo "Skipping tests: only doc changes"
+            FILTERS='.key != "lint" and .key != "test"'
+          else  # RUN_TESTS=0, RUN_DOCS=0
+            echo "What is this PR doing??"
+            FILTERS='.key != "lint" and .key != "test" and .key != "docs"'
           fi
+
+          check_jobs "$FILTERS"
           echo "CI says: Looks good!"
 
 {%- if post_job_template %}

--- a/templates/github/.github/workflows/docs.yml.j2
+++ b/templates/github/.github/workflows/docs.yml.j2
@@ -8,10 +8,14 @@ with context %}
 name: "Docs CI"
 on:
   workflow_call:
+    inputs:
+      run_docs:
+        description: "Whether to run docs jobs"
+        required: true
+        type: string
 
 jobs:
   changelog:
-    if: "endsWith(github.base_ref, '{{ plugin_default_branch }}')"
     runs-on: "ubuntu-latest"
     defaults:
       run:
@@ -24,14 +28,7 @@ jobs:
         run: |
           towncrier build --yes --version 4.0.0.ci
   docs:
-    if: "endsWith(github.base_ref, '{{ plugin_default_branch }}')"
+    if: {{ '${{ inputs.run_docs == \'1\' }}' }}
     uses: 'pulp/pulp-docs/.github/workflows/docs-ci.yml@{{ pulpdocs_branch }}'
     with:
       pulpdocs_ref: '{{ pulpdocs_branch }}'
-
-  no-test:
-    if: "!endsWith(github.base_ref, '{{ plugin_default_branch }}')"
-    runs-on: "ubuntu-latest"
-    steps:
-      - run: |
-          echo "Skip docs testing on non-default branches."


### PR DESCRIPTION
We were skipping docs for non-default branches using a not very elegant solution. This standadizes the processes of doing job checks on ci.yml