### PR TITLE
Remove *.txt pattern as a doc-only change

### DIFF
--- a/templates/github/.ci/scripts/skip_tests.py
+++ b/templates/github/.ci/scripts/skip_tests.py
@@ -25,7 +25,6 @@ import argparse
 DOC_PATTERNS = [
     r"^docs/",
     r"\.md$",
-    r"\.txt$",
     r"LICENSE.*",
     r"CHANGELOG.*",
     r"CHANGES.*",


### PR DESCRIPTION
In practice, `*.txt` are more often some a requirement file than a docs file, and modifying such files should not be considered a docs-only change.

Example: https://github.com/pulp/pulp_maven/pull/291