### PR TITLE
Fix python-build for PEP 625

### DIFF
--- a/templates/github/.github/workflows/scripts/build_python_client.sh.j2
+++ b/templates/github/.github/workflows/scripts/build_python_client.sh.j2
@@ -20,7 +20,7 @@ pushd {{ plugin.name | snake }}-client
 python setup.py sdist bdist_wheel --python-tag py3
 
 twine check "dist/{{ plugin.name | snake }}_client-"*"-py3-none-any.whl"
-twine check "dist/{{ plugin.name | snake }}-client-"*".tar.gz"
+twine check "dist/{{ plugin.name | snake }}_client-"*".tar.gz"
 
 tar cvf "../../{{ plugin_name }}/{{ plugin.app_label }}-python-client.tar" ./dist
 


### PR DESCRIPTION
This change addresses the deprecation PyPi warned us about:

"In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.

Specifically, your recent upload of 'pulp_container-client-2.26.3.tar.gz' is incompatible with PEP 625 because the filename does not contain the normalized project name 'pulp_container_client'."