### PR TITLE
Use build instead of deprecated setup.py

### DIFF
--- a/templates/github/.github/workflows/scripts/build_python_client.sh.j2
+++ b/templates/github/.github/workflows/scripts/build_python_client.sh.j2
@@ -17,7 +17,7 @@ rm -rf "{{ plugin.name | snake }}-client"
 ./gen-client.sh "../{{ plugin_name }}/{{ plugin.app_label }}-api.json" "{{ plugin.app_label }}" python "{{ plugin.name | snake }}"
 
 pushd {{ plugin.name | snake }}-client
-python setup.py sdist bdist_wheel --python-tag py3
+python -m build
 
 twine check "dist/{{ plugin.name | snake }}_client-"*"-py3-none-any.whl"
 twine check "dist/{{ plugin.name | snake }}_client-"*".tar.gz"

--- a/templates/github/.github/workflows/scripts/publish_client_pypi.sh.j2
+++ b/templates/github/.github/workflows/scripts/publish_client_pypi.sh.j2
@@ -18,6 +18,6 @@ fi
 twine upload -u __token__ -p "${PYPI_API_TOKEN}" \
 {%- for plugin in plugins %}
 "dist/{{ plugin.name | snake }}_client-${VERSION}-py3-none-any.whl" \
-"dist/{{ plugin.name | snake }}-client-${VERSION}.tar.gz" \
+"dist/{{ plugin.name | snake }}_client-${VERSION}.tar.gz" \
 {%- endfor %}
 ;

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -67,7 +67,7 @@ pushd ../pulp-openapi-generator
       rm -rf "./${PACKAGE}-client"
       ./gen-client.sh "${COMPONENT}-api.json" "${COMPONENT}" python "${PACKAGE}"
       pushd "${PACKAGE}-client"
-        python setup.py sdist bdist_wheel --python-tag py3
+        python -m build
       popd
     else
       if [ ! -f "${PACKAGE}-client/dist/${PACKAGE}_client-${VERSION}-py3-none-any.whl" ]

--- a/templates/github/.github/workflows/test.yml.j2
+++ b/templates/github/.github/workflows/test.yml.j2
@@ -67,7 +67,7 @@ jobs:
           {%- endfor %}
       {%- endif %}
 
-      {{ install_python_deps(["towncrier", "twine", "wheel", "httpie", "docker", "netaddr", "boto3", "ansible~=10.3.0", "mkdocs", "jq", "jsonpatch", "bump-my-version", "click<8.3"]) | indent(6) }}
+      {{ install_python_deps(["build", "towncrier", "twine", "wheel", "httpie", "docker", "netaddr", "boto3", "ansible~=10.3.0", "mkdocs", "jq", "jsonpatch", "bump-my-version", "click<8.3"]) | indent(6) }}
 
       {{ setup_env() | indent(6) }}
 


### PR DESCRIPTION
Support for PEP625 was [added in setuptools 69.3.0](https://setuptools.pypa.io/en/stable/history.html#v69-3-0). There is also a fix for [name normalization in 70.2.0](https://setuptools.pypa.io/en/stable/history.html#v70-2-0).

The generated clients generates pyproject and setup.py files, but it doesnt specifiy the required setuptools version.
I suspect it could possibly be using a setuptools version for the build which doesnt know how to generate the normalized names.

Furthermore, we were building the client using `python setup.py`, which is deprecated for quite some time now. Just switcthing to use `python -m build` fixed the name. Possibly `build` uses a more appropriate setuptools version.

Also opened [a pulp-openapi-generator PR](https://github.com/pulp/pulp-openapi-generator/pull/122) to test, but just replacing `python setup.py` seems to do the trick.