### PR TITLE
Update publish workflow to use PyPI Trusted Publisher

### DIFF
--- a/templates/github/.github/workflows/publish.yml.j2
+++ b/templates/github/.github/workflows/publish.yml.j2
@@ -59,10 +59,13 @@ jobs:
       id-token: "write"
 
     steps:
+      {{ checkout(depth=1, path=plugin_name) | indent(6) }}
+
       - name: "Download Python client"
         uses: "actions/download-artifact@v4"
         with:
           name: "python-client.tar"
+          path: "{{ plugin_name }}/"
 
       - name: "Untar python client packages"
         run: |
@@ -72,6 +75,8 @@ jobs:
 
       - name: "Publish client to pypi"
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: "{{ plugin_name }}/dist/"
   {%- endif %}
 
   {%- if deploy_client_to_rubygems %}
@@ -85,10 +90,13 @@ jobs:
       id-token: "write"
 
     steps:
+      {{ checkout(depth=1, path=plugin_name) | indent(6) }}
+
       - name: "Download Ruby client"
         uses: "actions/download-artifact@v4"
         with:
           name: "ruby-client.tar"
+          path: "{{ plugin_name }}/"
 
       - name: "Untar Ruby client packages"
         run: |


### PR DESCRIPTION
Requires adding the trusted publisher to each project + client's PyPI page. Also, the GitHub "pypi" environment we are using is autocreated once the workflow is merged and ran, but you can create it before hand and assign it permissions for when it is allowed to run. ~~In ostree I created it before hand and applied the same branch protection rules we use  to only allow the environment to run on protected branches.~~

https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments