### PR TITLE
Fix pulpcore plugin comparison

### DIFF
--- a/templates/github/pyproject.toml.tool.j2
+++ b/templates/github/pyproject.toml.tool.j2
@@ -74,7 +74,7 @@ extend-select = [
   "TID",
   "T10",
 ]
-{%- if plugin_name != "core" %}
+{%- if plugin_name != "pulpcore" %}
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 # This section is managed by the plugin template. Do not edit manually.


### PR DESCRIPTION
The correct comparison is "pulpcore", not "core".