### PR TITLE
Filter pulp-cli livetest to the plugin under test

### DIFF
--- a/CHANGES/+filter-cli-livetest.bugfix
+++ b/CHANGES/+filter-cli-livetest.bugfix
@@ -1,0 +1,1 @@
+Filter pulp-cli livetest runs to the plugin under test when using pulp-cli 0.40.0+.

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -159,13 +159,14 @@ export PULP_FIXTURES_URL="http://pulp-fixtures:8080"
 {%- endif %}
 # some pulp-cli tests use the api root envvar
 export PULP_API_ROOT="$(EDITOR=cat pulp config edit 2>/dev/null | awk -F'"' '/api_root/{print $2; exit}')"
+{%- set cli_plugin_markers = plugins | map(attribute='name') | join(' or ') | snake %}
 pushd ../{{ cli_package }}
 if [[ -f "test_requirements.txt" ]]
 then
   pip install -r test_requirements.txt
-  pytest -v tests -m "{{ plugins | map(attribute='name') | join(' or ') | snake }}"
+  pytest -v tests -m "{{ cli_plugin_markers }}"
 else
-  PULP_CA_BUNDLE="/usr/local/share/ca-certificates/pulp_webserver.crt" make livetest
+  PULP_CA_BUNDLE="/usr/local/share/ca-certificates/pulp_webserver.crt" make livetest PYTEST_MARK="live and ({{ cli_plugin_markers }})"
 fi
 popd
 {%- endif %}


### PR DESCRIPTION
## Summary
- Pass `PYTEST_MARK="live and (<plugin markers>)"` when invoking `make livetest` for pulp-cli 0.40.0+, which no longer ships `test_requirements.txt`
- Keeps the existing path for older pulp-cli versions that install test deps from `test_requirements.txt` and run filtered pytest directly

Depends on https://github.com/pulp/pulp-cli/pull/1419, which adds the `PYTEST_MARK` variable to the pulp-cli Makefile.

## Test plan
- [ ] Regenerate CI for a plugin (e.g. pulp_container) and confirm `script.sh` uses the filtered livetest invocation
- [ ] With pulp-cli < 0.40.0 checked out, CI still uses `test_requirements.txt` + `pytest -m "<plugin>"`
- [ ] With pulp-cli 0.40.0+ checked out, CI runs `make livetest PYTEST_MARK="live and pulp_container"` (or equivalent for multi-plugin repos)


Made with [Cursor](https://cursor.com)