### PR TITLE
Add black to linting requirements

### DIFF
--- a/templates/github/lint_requirements.txt.j2
+++ b/templates/github/lint_requirements.txt.j2
@@ -5,3 +5,4 @@ check-manifest
 packaging
 ruff
 yamllint
+black


### PR DESCRIPTION
<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)

Fixes https://github.com/pulp/pulp_deb/issues/1471
PR created here due to this [note](https://github.com/pulp/pulp_deb/blob/7fd34fc3fbc844338b8450c5e870c40b3531cd9c/lint_requirements.txt#L3)
Let me know if this should be fixed in any other way.