### PR TITLE
Set ruff select setting for 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ line-length = 100
 extend-exclude = ["templates"]
 
 [tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
 extend-select = ["I"]

--- a/templates/github/pyproject.toml.tool.j2
+++ b/templates/github/pyproject.toml.tool.j2
@@ -68,6 +68,7 @@ extend-exclude = [
 
 [tool.ruff.lint]
 # This section is managed by the plugin template. Do not edit manually.
+select = ["E4", "E7", "E9", "F"]
 extend-select = [
   "I",
   "INT",


### PR DESCRIPTION
The new release of ruff 0.16.0 is raising hundreds of new errors for plugins. This sets select back to what it was < 0.16.0.

Blog post with more info:

https://astral.sh/blog/ruff-v0.16.0#better-default-rule-set