### PR TITLE
Switch CI package installs from pip to uv.

### DIFF
--- a/.ci/bootstrap_catdog.sh
+++ b/.ci/bootstrap_catdog.sh
@@ -11,7 +11,8 @@ else
 fi
 echo "${COMMIT_MSG}"
 
-pip install -r test_requirements.txt
+uv pip install -r test_requirements.txt
+
 ./plugin-template --generate-config --plugin-app-label catdog pulp_catdog
 mkdir -p ../pulp_catdog/.ci/assets/bindings
 sed -i "s/test_s3: false/test_s3: true/g" ../pulp_catdog/template_config.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: "Build"
 on:
   workflow_call:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "pulp_catdog"
@@ -20,6 +23,10 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
       - name: "Bootstrap catdog plugin"
         working-directory: "plugin_template"
         run: |
@@ -34,14 +41,14 @@ jobs:
           path: "pulp-openapi-generator"
       - name: "Install python dependencies"
         run: |
-          pip install build packaging twine wheel mkdocs jq
+          uv pip install build packaging twine wheel mkdocs jq
       - name: "Build package"
         run: |
           python3 -m build
           twine check dist/*
       - name: "Install built packages"
         run: |
-          pip install dist/pulp_catdog-*-py3-none-any.whl -c .ci/assets/ci_constraints.txt
+          uv pip install dist/pulp_catdog-*-py3-none-any.whl -c .ci/assets/ci_constraints.txt
       - name: "Generate api specs"
         run: |
           pulpcore-manager openapi --file "api.json"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 name: "Test bootstrapping a plugin"
 on: {pull_request: {branches: ['*']}}
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 concurrency:
   group: ${{ github.ref_name }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -21,6 +24,10 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
       - name: "Bootstrap catdog plugin"
         working-directory: "plugin_template"
         run: |
@@ -29,7 +36,7 @@ jobs:
       # Below this line we include the steps of the ci workflow of the generated plugin
       - name: "Install python dependencies"
         run: |
-          pip install requests pygithub pyyaml
+          uv pip install requests pygithub pyyaml
       - name: "Check commit message"
         # This will fail for our fake plugin
         if: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ name: "Lint"
 on:
   workflow_call:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "pulp_catdog"
@@ -27,10 +30,14 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
       - name: "Lint plugin_template"
         working-directory: "plugin_template"
         run: |
-          pip3 install ruff
+          uv pip install ruff
           ruff format --check --diff plugin-template utils.py
           ruff check plugin-template utils.py
       - name: "Bootstrap catdog plugin"
@@ -42,7 +49,7 @@ jobs:
 
       - name: "Install python dependencies"
         run: |
-          pip install -r lint_requirements.txt
+          uv pip install -r lint_requirements.txt
 
       - name: "Lint workflow files"
         run: |

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -17,6 +17,9 @@ on:
       - "main"
       - "[0-9]+.[0-9]+"
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 # This workflow runs with elevated permissions.
 # Do not even think about running a single bit of code from the PR.
 # Static analysis should be fine however.
@@ -38,9 +41,13 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
       - name: "Determine PR labels"
         run: |
-          pip install GitPython==3.1.42
+          uv pip install GitPython==3.1.42
           git fetch origin ${{ github.event.pull_request.head.sha }}
           python .ci/scripts/pr_labels.py "origin/${{ github.base_ref }}" "${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
       - uses: "actions/github-script@v8"

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -13,6 +13,9 @@ name: "Sanity"
 on:
   workflow_call:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "pulp_catdog"
@@ -32,6 +35,11 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
+
       - name: "Bootstrap catdog plugin"
         working-directory: "plugin_template"
         run: |
@@ -40,7 +48,7 @@ jobs:
       # Below this line we include the steps of the ci workflow of the generated plugin
       - name: "Install python dependencies"
         run: |
-          pip install -r lint_requirements.txt
+          uv pip install -r lint_requirements.txt
 
       - name: "Verify bump version config"
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: "string"
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "pulp_catdog"
@@ -36,6 +39,11 @@ jobs:
       - uses: "actions/setup-python@v6"
         with:
           python-version: "3.11"
+
+      - name: "Install uv"
+        uses: "astral-sh/setup-uv@v7"
+        with:
+          enable-cache: true
 
       - name: "Bootstrap catdog plugin"
         working-directory: "plugin_template"
@@ -78,7 +86,7 @@ jobs:
 
       - name: "Install python dependencies"
         run: |
-          pip install build towncrier twine wheel httpie docker netaddr boto3 'ansible~=10.3.0' mkdocs jq jsonpatch bump-my-version
+          uv pip install build towncrier twine wheel httpie docker netaddr boto3 'ansible~=10.3.0' mkdocs jq jsonpatch bump-my-version
           echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/pulp_catdog/.ci/assets/httpie/" >> $GITHUB_ENV
 
       - name: "Set environment variables"
@@ -148,5 +156,5 @@ jobs:
           docker logs pulp || true
           docker exec pulp ls -latr /etc/yum.repos.d/ || true
           docker exec pulp cat /etc/yum.repos.d/* || true
-          docker exec pulp bash -c "pip3 list" || true
+          docker exec pulp bash -c "uv pip list" || true
 ...

--- a/templates/github/.ci/ansible/Containerfile.j2.copy
+++ b/templates/github/.ci/ansible/Containerfile.j2.copy
@@ -9,7 +9,7 @@ ADD ./{{ plugin_name }}/{{ plugin_name | replace("-", "_") }}/app/webserver_snip
 ADD ./{{ item.origin }} {{ item.destination }}
 {%- endfor %}
 
-# This MUST be the ONLY call to pip install in inside the container.
+# This MUST be the ONLY package install inside the container.
 RUN --mount=type=cache,target=/root/.cache/uv uv pip install --upgrade setuptools wheel && \
   uv pip install {{ image.source }}
 {%- if image.upperbounds | default(false) -%}

--- a/templates/github/.github/workflows/build.yml.j2
+++ b/templates/github/.github/workflows/build.yml.j2
@@ -10,6 +10,9 @@ name: "Build"
 on:
   workflow_call:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "{{ plugin_name }}"
@@ -35,7 +38,7 @@ jobs:
           twine check dist/*
       - name: "Install built packages"
         run: |
-          pip install dist/{{ plugin_name | snake }}-*-py3-none-any.whl -c .ci/assets/ci_constraints.txt
+          uv pip install dist/{{ plugin_name | snake }}-*-py3-none-any.whl -c .ci/assets/ci_constraints.txt
       - name: "Generate api specs"
         run: |
           pulpcore-manager openapi --file "api.json"

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -10,6 +10,9 @@ with context %}
 name: "{{ plugin_app_label | camel }} CI"
 on: {{ ci_trigger | default("{pull_request: {branches: ['*']}}") }}
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 concurrency:
   group: {{ '${{ github.ref_name }}-${{ github.workflow }}' }}
   cancel-in-progress: true

--- a/templates/github/.github/workflows/create-branch.yml.j2
+++ b/templates/github/.github/workflows/create-branch.yml.j2
@@ -12,6 +12,7 @@ on:
 
 env:
   RELEASE_WORKFLOW: true
+  UV_SYSTEM_PYTHON: "1"
 
 jobs:
   create-branch:

--- a/templates/github/.github/workflows/docs.yml.j2
+++ b/templates/github/.github/workflows/docs.yml.j2
@@ -14,6 +14,9 @@ on:
         required: true
         type: "string"
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 jobs:
   changelog:
     runs-on: "ubuntu-latest"

--- a/templates/github/.github/workflows/lint.yml.j2
+++ b/templates/github/.github/workflows/lint.yml.j2
@@ -9,6 +9,9 @@ name: "Lint"
 on:
   workflow_call:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "{{ plugin_name }}"

--- a/templates/github/.github/workflows/nightly.yml.j2
+++ b/templates/github/.github/workflows/nightly.yml.j2
@@ -18,6 +18,9 @@ on:
     - cron: "00 3 * * *"
   workflow_dispatch:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "{{ plugin_name }}"

--- a/templates/github/.github/workflows/pr_checks.yml.j2
+++ b/templates/github/.github/workflows/pr_checks.yml.j2
@@ -15,6 +15,9 @@ on:
       - "{{ plugin_default_branch }}"
       - "[0-9]+.[0-9]+"
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 # This workflow runs with elevated permissions.
 # Do not even think about running a single bit of code from the PR.
 # Static analysis should be fine however.
@@ -37,7 +40,7 @@ jobs:
       - name: "Determine PR labels"
         run: |
           {%- raw %}
-          pip install GitPython==3.1.42
+          uv pip install GitPython==3.1.42
           git fetch origin ${{ github.event.pull_request.head.sha }}
           python .ci/scripts/pr_labels.py "origin/${{ github.base_ref }}" "${{ github.event.pull_request.head.sha }}" >> "$GITHUB_ENV"
           {%- endraw %}

--- a/templates/github/.github/workflows/publish.yml.j2
+++ b/templates/github/.github/workflows/publish.yml.j2
@@ -17,6 +17,9 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "{{ plugin_name }}"
@@ -148,7 +151,7 @@ jobs:
 
       - name: "Install towncrier"
         run: |
-          pip install towncrier
+          uv pip install towncrier
 
       - name: "Get release notes"
         id: "get_release_notes"

--- a/templates/github/.github/workflows/release.yml.j2
+++ b/templates/github/.github/workflows/release.yml.j2
@@ -15,6 +15,9 @@ name: {{ plugin_app_label | camel }} Release Pipeline
 on:
   workflow_dispatch:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "{{ plugin_name }}"

--- a/templates/github/.github/workflows/sanity.yml.j2
+++ b/templates/github/.github/workflows/sanity.yml.j2
@@ -12,6 +12,9 @@ name: "Sanity"
 on:
   workflow_call:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 defaults:
   run:
     working-directory: "{{ plugin_name }}"

--- a/templates/github/.github/workflows/scripts/before_script.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_script.sh.j2
@@ -36,12 +36,12 @@ echo "# Constraints Files:"
 tail -v -n +1  ../*/*constraints.txt || true
 
 echo
-echo "# pip list outside the container"
-pip list
+echo "# package list outside the container"
+uv pip list
 
 echo
-echo "# pip list inside the container"
-cmd_prefix bash -c "pip3 list"
+echo "# package list inside the container"
+cmd_prefix bash -c "uv pip list"
 
 echo
 echo "# State of the containers"

--- a/templates/github/.github/workflows/scripts/install.sh.j2
+++ b/templates/github/.github/workflows/scripts/install.sh.j2
@@ -12,8 +12,8 @@ source .github/workflows/scripts/utils.sh
 
 PIP_REQUIREMENTS=("{{ cli_package }}" "yq")
 
-# This must be the **only** call to "pip install" on the test runner.
-pip install ${PIP_REQUIREMENTS[*]}
+# This must be the **only** package install on the test runner.
+uv pip install ${PIP_REQUIREMENTS[*]}
 
 if [[ "$TEST" = "s3" ]]; then
 for i in {1..3}
@@ -29,7 +29,7 @@ fi
 {%- if test_cli %}
 
 # Check out the {{ cli_package }} branch matching the installed version.
-PULP_CLI_VERSION="$(pip freeze | sed -n -e 's/{{ cli_package }}==//p')"
+PULP_CLI_VERSION="$(uv pip freeze | sed -n -e 's/{{ cli_package }}==//p')"
 git clone --depth 1 --branch "$PULP_CLI_VERSION" {{ cli_repo }} ../{{ cli_package }}
 {%- endif %}
 

--- a/templates/github/.github/workflows/scripts/script.sh.j2
+++ b/templates/github/.github/workflows/scripts/script.sh.j2
@@ -105,7 +105,7 @@ cmd_stdin_prefix bash -c "cat > /tmp/unittest_requirements.txt" < unittest_requi
 cmd_stdin_prefix bash -c "cat > /tmp/functest_requirements.txt" < functest_requirements.txt
 cmd_stdin_prefix bash -c "cat > /tmp/bindings_requirements.txt" < bindings_requirements.txt
 cmd_stdin_prefix bash -c "cat > /tmp/bindings_constraints.txt" < bindings_constraints.txt
-cmd_prefix pip3 install -r /tmp/unittest_requirements.txt -r /tmp/functest_requirements.txt -r /tmp/bindings_requirements.txt -c /tmp/bindings_constraints.txt
+cmd_prefix uv pip install -r /tmp/unittest_requirements.txt -r /tmp/functest_requirements.txt -r /tmp/bindings_requirements.txt -c /tmp/bindings_constraints.txt
 
 CERTIFI=$(cmd_prefix python3 -c 'import certifi; print(certifi.where())')
 cmd_prefix bash -c "cat /etc/pulp/certs/pulp_webserver.crt >> '$CERTIFI'"
@@ -163,7 +163,7 @@ export PULP_API_ROOT="$(EDITOR=cat pulp config edit 2>/dev/null | awk -F'"' '/ap
 pushd ../{{ cli_package }}
 if [[ -f "test_requirements.txt" ]]
 then
-  pip install -r test_requirements.txt
+  uv pip install -r test_requirements.txt
   pytest -v tests -m "{{ cli_plugin_markers }}"
 else
   PULP_CA_BUNDLE="/usr/local/share/ca-certificates/pulp_webserver.crt" make livetest PYTEST_MARK="live and ({{ cli_plugin_markers }})"

--- a/templates/github/.github/workflows/test.yml.j2
+++ b/templates/github/.github/workflows/test.yml.j2
@@ -3,7 +3,6 @@
   checkout,
   display_logs,
   install_python_deps,
-  install_uv,
   run_script,
   setup_env,
   setup_python,
@@ -16,6 +15,9 @@ on:
       matrix_env:
         required: true
         type: "string"
+
+env:
+  UV_SYSTEM_PYTHON: "1"
 
 defaults:
   run:
@@ -37,8 +39,6 @@ jobs:
       {{ checkout(repository="pulp/pulp-openapi-generator", path="pulp-openapi-generator") | indent(6) }}
 
       {{ setup_python() | indent(6) }}
-
-      {{ install_uv() | indent(6) }}
 
       - name: "Download plugin package"
         uses: "actions/download-artifact@v8"

--- a/templates/github/.github/workflows/update-labels.yml.j2
+++ b/templates/github/.github/workflows/update-labels.yml.j2
@@ -14,6 +14,9 @@ on:
     paths:
       - "template_config.yml"
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 jobs:
   update_backport_labels:
     runs-on: "ubuntu-latest"

--- a/templates/github/.github/workflows/update_ci.yml.j2
+++ b/templates/github/.github/workflows/update_ci.yml.j2
@@ -17,6 +17,9 @@ on:
   {%- endif %}
   workflow_dispatch:
 
+env:
+  UV_SYSTEM_PYTHON: "1"
+
 jobs:
   update:
     runs-on: "ubuntu-latest"

--- a/templates/include/macros.j2
+++ b/templates/include/macros.j2
@@ -37,6 +37,7 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
 - uses: "actions/setup-python@v6"
   with:
     python-version: "{{ pyversion }}"
+{{ install_uv() }}
 {%- endmacro -%}
 
 
@@ -61,7 +62,7 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
 {%- macro install_python_deps(deps=[]) -%}
 - name: "Install python dependencies"
   run: |
-    pip install {{ deps | map("shquote") | join(" ") }}
+    uv pip install {{ deps | map("shquote") | join(" ") }}
     {%- if 'httpie' in deps %}
     echo "HTTPIE_CONFIG_DIR=$GITHUB_WORKSPACE/{{ plugin_name }}/.ci/assets/httpie/" >> $GITHUB_ENV
     {%- endif %}
@@ -95,7 +96,7 @@ GITHUB_CONTEXT: "{{ '${{ github.event.pull_request.commits_url }}' }}"
     docker logs pulp || true
     docker exec pulp ls -latr /etc/yum.repos.d/ || true
     docker exec pulp cat /etc/yum.repos.d/* || true
-    docker exec pulp bash -c "pip3 list" || true
+    docker exec pulp bash -c "uv pip list" || true
 {%- endmacro -%}
 
 


### PR DESCRIPTION
Use astral-sh/setup-uv with UV_SYSTEM_PYTHON=1 as a workflow-level env so host and container installs go through uv pip.
https://redhat.atlassian.net/browse/PULP-2235

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
