### PR TITLE
Replace forked botocore dependency with feature flag BOTO_EXPERIMENTAL__NO_EMPTY_CONTINUE=true

### DIFF
--- a/templates/github/.github/workflows/scripts/before_install.sh.j2
+++ b/templates/github/.github/workflows/scripts/before_install.sh.j2
@@ -24,7 +24,7 @@ COMPONENT_SOURCE="./{{ plugin_name }}/dist/{{ plugin_name | snake }}-${COMPONENT
 {%- set PULPCORE_PREFIX = "" if plugin_name == "pulpcore" else " pulpcore" %}
 {%- if test_s3 %}
 if [ "$TEST" = "s3" ]; then
-  COMPONENT_SOURCE="${COMPONENT_SOURCE}{{ PULPCORE_PREFIX }}[s3] git+https://github.com/gerrod3/botocore.git@fix-100-continue"
+  COMPONENT_SOURCE="${COMPONENT_SOURCE}{{ PULPCORE_PREFIX }}[s3]"
 fi
 {%- endif %}
 {%- if test_azure %}
@@ -109,7 +109,8 @@ s3_test: true
 minio_access_key: "${MINIO_ACCESS_KEY}"
 minio_secret_key: "${MINIO_SECRET_KEY}"
 pulp_scenario_settings: {{ pulp_settings_s3 | tojson }}
-pulp_scenario_env: {{ pulp_env_s3 | tojson }}
+# MinIO omits 100-continue on 0-byte PUTs; stock botocore hangs without this (boto/botocore#3123).
+pulp_scenario_env: {{ dict({"BOTO_EXPERIMENTAL__NO_EMPTY_CONTINUE": "true"}, **(pulp_env_s3 or {})) | tojson }}
 VARSYAML
 fi
 


### PR DESCRIPTION
This should speed up the uv pip install for the s3 runner to be as fast as the other runners 2~3 secs

Generated-by: cursor-grok-4.6

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
