### PR TITLE
Derive the CI Python version from the package's requires-python.

### DIFF
--- a/CHANGES/+min-python-from-package.feature
+++ b/CHANGES/+min-python-from-package.feature
@@ -1,0 +1,1 @@
+Read the package's `requires-python` and use that minimum version when installing Python in CI.

--- a/plugin-template
+++ b/plugin-template
@@ -389,7 +389,7 @@ def write_template_section(
         "section": section,
         "setup_py": (plugin_root_dir / "setup.py").exists(),
         "ci_update_branches": utils.ci_update_branches(config),
-        "python_version": "3.11",
+        "python_version": utils.min_python_version(plugin_root_dir),
         "ci_update_hour": sum((ord(c) for c in config["plugin_app_label"])) % 24,
         "current_version": utils.current_version(plugin_root_dir),
         "pulpdocs_branch": PULPDOCS_BRANCH,

--- a/templates/github/.github/workflows/ci.yml.j2
+++ b/templates/github/.github/workflows/ci.yml.j2
@@ -49,7 +49,7 @@ jobs:
     steps:
       {{ checkout(depth=0, path=plugin_name) | indent(6) }}
 
-      {{ setup_python("3.12") | indent(6) }}
+      {{ setup_python() | indent(6) }}
 
       {{ install_python_deps(["gitpython"]) | indent(6) }}
 

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,8 @@ import requests_cache
 import tomlkit
 import tomllib
 import yaml
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 # Jinja tests and filters
 
@@ -92,6 +94,30 @@ def current_version(plugin_root_path):
         except Exception:
             current_version = "0.0.0.dev"
     return current_version
+
+
+DEFAULT_PYTHON_VERSION = "3.11"
+_PYTHON_MINOR_RANGE = range(6, 40)
+
+
+def python_version_from_requires(requires_python):
+    """Return the lowest CPython 3.x series that can satisfy requires-python."""
+    spec = SpecifierSet(requires_python)
+    for minor in _PYTHON_MINOR_RANGE:
+        # Probe a high micro so ">=3.11.4" still selects the 3.11 series.
+        if Version(f"3.{minor}.999") in spec:
+            return f"3.{minor}"
+    return DEFAULT_PYTHON_VERSION
+
+
+def min_python_version(plugin_root_path):
+    """Read [project] requires-python and return the minimum 3.x series, e.g. '3.11'."""
+    try:
+        path = plugin_root_path / "pyproject.toml"
+        requires_python = tomllib.loads(path.read_text())["project"]["requires-python"]
+        return python_version_from_requires(requires_python)
+    except Exception:
+        return DEFAULT_PYTHON_VERSION
 
 
 def get_pulpdocs_members(pulpdocs_branch="main") -> list[str]:


### PR DESCRIPTION
This will allow us to upgrade to require>=3.12 without worry of older branches.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
